### PR TITLE
Docs are not clear, need update. iCloud sync is not working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ To setup iCloud Drive Sync, follow these steps:
 
 > Sometimes it may take some time for the folder to appear on the finder and files app, but you can access it via terminal.
 
-3. After the folder is created, navigate to it from your computer, and copy your `taskchampion.sqlite3` file into `~/Library/Mobile Documents/iCloud~com~mav~taskchamp/Documents/taskchamp/`. Replace the existing file if there is one.
+3. After the folder is created, navigate to it from your computer, and copy your `taskchampion.sqlite3` file into `~/Library/Mobile Documents/iCloud~com~mav~taskchamp/Documents/taskchamp/`. Replace the existing file if there is one. Once the initial database load is complete, delete the taskchampion.sqlite3 file from this folder. After removing the file, the iOS app will  perform a correct sync.
 
 > [!NOTE]
 > You do not need to move the file, just a copy will do. This is just to make sure that the files have a shared starting point.


### PR DESCRIPTION
In order to make syncing work, after initial load of database, you need to remove taskchamp.sqlite3 file. After this action IOS app will perform correct sync. Its not mentioned in docs. 

> After the folder is created, navigate to it from your computer, and copy your taskchampion.sqlite3 file into ~/Library/Mobile Documents/iCloud~com~mav~taskchamp/Documents/taskchamp/. Replace the existing file if there is one.


