### PR TITLE
Add location-based reminders and critical alerts

### DIFF
--- a/Derived/Entitlements/taskchamp.entitlements
+++ b/Derived/Entitlements/taskchamp.entitlements
@@ -15,6 +15,8 @@
 	<array>
 		<string>iCloud.com.mav.taskchamp</string>
 	</array>
+	<key>com.apple.developer.usernotifications.critical-alerts</key>
+	<true/>
 	<key>com.apple.developer.usernotifications.time-sensitive</key>
 	<true/>
 	<key>com.apple.security.application-groups</key>

--- a/Derived/InfoPlists/taskchamp-Info.plist
+++ b/Derived/InfoPlists/taskchamp-Info.plist
@@ -24,6 +24,10 @@
 	<true/>
 	<key>NSAccentColorName</key>
 	<string>AccentColor</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Taskchamp needs background location access to notify you when you arrive at or leave a location for your task reminders.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Taskchamp uses your location to show nearby places when setting location-based reminders.</string>
 	<key>NSUbiquitousContainers</key>
 	<dict>
 		<key>iCloud.com.mav.taskchamp</key>
@@ -43,6 +47,10 @@
 		<key>UISceneConfigurations</key>
 		<dict/>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>

--- a/Project.swift
+++ b/Project.swift
@@ -46,6 +46,7 @@ let project = Project(
                     "com.apple.developer.icloud-services": ["CloudDocuments", "CloudKit"],
                     "com.apple.developer.ubiquity-container-identifiers": ["iCloud.com.mav.taskchamp"],
                     "com.apple.developer.usernotifications.time-sensitive": true,
+                    "com.apple.developer.usernotifications.critical-alerts": true,
                     "com.apple.security.application-groups": ["group.com.mav.taskchamp"]
                 ]
             ),

--- a/Project.swift
+++ b/Project.swift
@@ -29,7 +29,13 @@ let project = Project(
                                 "NSUbiquitousContainerSupportedFolderLevels": "Any"
                             ]
                     ],
-                    "CFBundleShortVersionString": "3"
+                    "CFBundleShortVersionString": "3",
+                    "NSLocationWhenInUseUsageDescription":
+                        "Taskchamp uses your location to show nearby places when setting location-based reminders.",
+                    "NSLocationAlwaysAndWhenInUseUsageDescription":
+                        // swiftlint:disable:next line_length
+                        "Taskchamp needs background location access to notify you when you arrive at or leave a location for your task reminders.",
+                    "UIBackgroundModes": ["location"]
                 ]
             ),
             sources: ["taskchamp/Sources/**"],

--- a/taskchamp/Sources/View/Cells/TaskCellView.swift
+++ b/taskchamp/Sources/View/Cells/TaskCellView.swift
@@ -20,9 +20,20 @@ public struct TaskCellView: View {
             .padding(.vertical, 3)
             HStack {
                 if task.due != nil {
-                    Text(task.localDate)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                    HStack(spacing: 4) {
+                        Text(task.localDate)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                        if task.hasCriticalAlert {
+                            Image(systemName: "bell.badge.fill")
+                                .font(.caption)
+                                .foregroundStyle(.red)
+                        }
+                    }
+                } else if task.hasCriticalAlert {
+                    Image(systemName: "bell.badge.fill")
+                        .font(.caption)
+                        .foregroundStyle(.red)
                 }
                 Spacer()
                 if let priority = task.priority {

--- a/taskchamp/Sources/View/Components/CriticalAlertSettingsView.swift
+++ b/taskchamp/Sources/View/Components/CriticalAlertSettingsView.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+import taskchampShared
+
+/// A view that displays critical alert settings for a task reminder.
+/// This view is always visible under the priority selector in task creation/editing views.
+public struct CriticalAlertSettingsView: View {
+    @Binding var criticalAlert: TCCriticalAlert?
+    @Binding var hasDueDate: Bool
+
+    @State private var isEnabled: Bool = false
+    @State private var volumePreset: TCCriticalAlertVolumePreset = .full
+    @State private var customVolume: Float = 1.0
+    @State private var criticalAlertStatus: CriticalAlertAuthorizationStatus = .notDetermined
+
+    private var canEnableCriticalAlert: Bool {
+        hasDueDate && criticalAlertStatus == .authorized
+    }
+
+    private var disabledReason: String? {
+        if criticalAlertStatus == .denied {
+            return "Critical alerts are denied. Enable in Settings."
+        } else if criticalAlertStatus == .notDetermined {
+            return "Critical alert permission not requested."
+        } else if !hasDueDate {
+            return "Set a due date to enable critical alerts."
+        }
+        return nil
+    }
+
+    public init(criticalAlert: Binding<TCCriticalAlert?>, hasDueDate: Binding<Bool>) {
+        self._criticalAlert = criticalAlert
+        self._hasDueDate = hasDueDate
+    }
+
+    public var body: some View {
+        Section {
+            // Critical Alert Toggle
+            Toggle(isOn: $isEnabled) {
+                Label {
+                    Text("Critical Alert")
+                } icon: {
+                    Image(systemName: isEnabled ? "bell.badge.fill" : "bell.badge")
+                        .foregroundStyle(isEnabled ? .red : .secondary)
+                }
+            }
+            .disabled(!canEnableCriticalAlert)
+            .onChange(of: isEnabled) { _, _ in
+                updateCriticalAlert()
+            }
+
+            // Volume Preset Selector - only enabled when toggle is ON
+            if isEnabled && canEnableCriticalAlert {
+                Picker("Volume", selection: $volumePreset) {
+                    ForEach(TCCriticalAlertVolumePreset.allCases, id: \.self) { preset in
+                        Text(preset.displayName).tag(preset)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .onChange(of: volumePreset) { _, newValue in
+                    if newValue != .custom {
+                        customVolume = newValue.volumeValue
+                    }
+                    updateCriticalAlert()
+                }
+
+                // Custom Volume Slider - only visible when Custom is selected
+                if volumePreset == .custom {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Image(systemName: "speaker.wave.1")
+                                .foregroundStyle(.secondary)
+                            Slider(value: $customVolume, in: 0.1...1.0, step: 0.05) {
+                                Text("Volume")
+                            }
+                            .onChange(of: customVolume) { _, _ in
+                                updateCriticalAlert()
+                            }
+                            Image(systemName: "speaker.wave.3")
+                                .foregroundStyle(.secondary)
+                            Text("\(Int(customVolume * 100))%")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .frame(width: 45, alignment: .trailing)
+                        }
+                    }
+                }
+            }
+
+            // Disabled reason or explanation
+            if let reason = disabledReason {
+                Text(reason)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else if isEnabled {
+                Text("Critical alerts sound even when muted or in Do Not Disturb.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        } header: {
+            HStack {
+                Text("Critical Alert")
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.caption)
+            }
+        }
+        .onAppear {
+            loadCurrentState()
+            criticalAlertStatus = NotificationService.shared.criticalAlertStatus
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(for: .TCCriticalAlertAuthorizationChanged)
+        ) { notification in
+            if let status = notification.object as? CriticalAlertAuthorizationStatus {
+                criticalAlertStatus = status
+            }
+        }
+    }
+
+    private func loadCurrentState() {
+        if let alert = criticalAlert {
+            isEnabled = alert.isEnabled
+            volumePreset = alert.volumePreset
+            customVolume = alert.customVolume
+        } else {
+            isEnabled = false
+            volumePreset = NotificationService.shared.defaultCriticalAlertVolumePreset
+            customVolume = volumePreset.volumeValue
+        }
+    }
+
+    private func updateCriticalAlert() {
+        if isEnabled {
+            criticalAlert = TCCriticalAlert(
+                isEnabled: true,
+                volumePreset: volumePreset,
+                customVolume: customVolume
+            )
+        } else {
+            criticalAlert = nil
+        }
+    }
+}

--- a/taskchamp/Sources/View/Components/LocationPickerView-Ext.swift
+++ b/taskchamp/Sources/View/Components/LocationPickerView-Ext.swift
@@ -1,0 +1,238 @@
+import CoreLocation
+import MapKit
+import SwiftUI
+import taskchampShared
+
+// MARK: - LocationPickerView Subviews
+
+extension LocationPickerView {
+    var searchBar: some View {
+        HStack {
+            Image(systemName: "magnifyingglass")
+                .foregroundColor(.secondary)
+
+            TextField("Search for a location", text: $searchText)
+                .textFieldStyle(.plain)
+                .autocorrectionDisabled()
+                .onChange(of: searchText) { _, newValue in
+                    isSearching = !newValue.isEmpty
+                    searchCompleter.search(query: newValue)
+                }
+                .onSubmit {
+                    if let first = searchResults.first {
+                        selectSearchResult(first)
+                    }
+                }
+
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                    isSearching = false
+                    searchResults = []
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .padding(10)
+        .background(Color(.systemGray6))
+        .cornerRadius(10)
+    }
+
+    var searchResultsList: some View {
+        List(searchResults, id: \.self) { result in
+            Button {
+                selectSearchResult(result)
+            } label: {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(result.title)
+                        .foregroundColor(.primary)
+                    if !result.subtitle.isEmpty {
+                        Text(result.subtitle)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+        }
+        .listStyle(.plain)
+    }
+
+    var mapView: some View {
+        Map(position: $cameraPosition) {
+            if let location = selectedLocation {
+                Marker(selectedLocationName, coordinate: location)
+                    .tint(.blue)
+
+                MapCircle(center: location, radius: radius)
+                    .foregroundStyle(.blue.opacity(0.2))
+                    .stroke(.blue, lineWidth: 2)
+            }
+        }
+        .mapControls {
+            MapUserLocationButton()
+            MapCompass()
+        }
+    }
+
+    var locationConfigCard: some View {
+        VStack(spacing: 16) {
+            HStack {
+                Image(systemName: "mappin.circle.fill")
+                    .foregroundColor(.blue)
+                    .font(.title2)
+
+                VStack(alignment: .leading) {
+                    Text(selectedLocationName)
+                        .font(.headline)
+                        .lineLimit(1)
+                    Text("Tap map to change location")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                Button(role: .destructive) {
+                    clearLocation()
+                } label: {
+                    Image(systemName: "trash")
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Radius: \(Int(radius))m")
+                        .font(.subheadline)
+                    Spacer()
+                }
+
+                Slider(value: $radius, in: minRadius ... maxRadius, step: 10) {
+                    Text("Radius")
+                }
+                .onChange(of: radius) { _, newRadius in
+                    updateMapRegion(with: newRadius)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Trigger when:")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+
+                HStack {
+                    Toggle("Arriving", isOn: $triggerOnArrival)
+                        .toggleStyle(.button)
+                        .buttonStyle(.bordered)
+                        .tint(triggerOnArrival ? .blue : .gray)
+
+                    Toggle("Leaving", isOn: $triggerOnDeparture)
+                        .toggleStyle(.button)
+                        .buttonStyle(.bordered)
+                        .tint(triggerOnDeparture ? .blue : .gray)
+                }
+            }
+        }
+        .padding()
+        .background(.regularMaterial)
+        .cornerRadius(16)
+        .padding()
+    }
+}
+
+// MARK: - LocationPickerView Methods
+
+extension LocationPickerView {
+    func selectSearchResult(_ result: MKLocalSearchCompletion) {
+        let searchRequest = MKLocalSearch.Request(completion: result)
+        let search = MKLocalSearch(request: searchRequest)
+
+        search.start { response, error in
+            if let error {
+                print("Search error: \(error.localizedDescription)")
+                return
+            }
+
+            guard let mapItem = response?.mapItems.first else {
+                return
+            }
+
+            let coordinate = mapItem.placemark.coordinate
+            selectedLocation = coordinate
+            selectedLocationName = result.title
+
+            cameraPosition = .region(
+                MKCoordinateRegion(
+                    center: coordinate,
+                    latitudinalMeters: radius * 4,
+                    longitudinalMeters: radius * 4
+                )
+            )
+
+            searchText = ""
+            isSearching = false
+            searchResults = []
+        }
+    }
+
+    func updateMapRegion(with newRadius: Double) {
+        guard let location = selectedLocation else { return }
+
+        cameraPosition = .region(
+            MKCoordinateRegion(
+                center: location,
+                latitudinalMeters: newRadius * 4,
+                longitudinalMeters: newRadius * 4
+            )
+        )
+    }
+
+    func clearLocation() {
+        selectedLocation = nil
+        selectedLocationName = ""
+        radius = 50
+        triggerOnArrival = true
+        triggerOnDeparture = false
+        cameraPosition = .automatic
+    }
+
+    func saveLocation() {
+        guard let location = selectedLocation else {
+            dismiss()
+            return
+        }
+
+        locationReminder = TCLocationReminder(
+            locationName: selectedLocationName,
+            latitude: location.latitude,
+            longitude: location.longitude,
+            radius: radius,
+            triggerOnArrival: triggerOnArrival,
+            triggerOnDeparture: triggerOnDeparture
+        )
+
+        dismiss()
+    }
+
+    func checkLocationAuthorization() {
+        let status = LocationService.shared.authorizationStatus
+
+        switch status {
+        case .notDetermined:
+            LocationService.shared.requestWhenInUseAuthorization()
+        case .denied, .restricted:
+            authorizationAlertMessage =
+                "Location access is required for location-based reminders. Please enable location access in Settings."
+            showAuthorizationAlert = true
+        case .authorizedWhenInUse:
+            if locationReminder != nil {
+                // swiftlint:disable:next line_length
+                authorizationAlertMessage = "For location reminders to work in the background, please enable 'Always' location access in Settings."
+                showAuthorizationAlert = true
+            }
+        case .authorizedAlways:
+            break
+        }
+    }
+}

--- a/taskchamp/Sources/View/Components/LocationPickerView.swift
+++ b/taskchamp/Sources/View/Components/LocationPickerView.swift
@@ -1,0 +1,101 @@
+import CoreLocation
+import MapKit
+import SwiftUI
+import taskchampShared
+
+public struct LocationPickerView: View {
+    @Environment(\.dismiss) var dismiss
+
+    @Binding var locationReminder: TCLocationReminder?
+
+    @State var searchText = ""
+    @State var searchResults: [MKLocalSearchCompletion] = []
+    @State var selectedLocation: CLLocationCoordinate2D?
+    @State var selectedLocationName = ""
+    @State var radius: Double = 50
+    @State var triggerOnArrival = true
+    @State var triggerOnDeparture = false
+
+    @State var cameraPosition: MapCameraPosition = .automatic
+    @State var isSearching = false
+    @State var showAuthorizationAlert = false
+    @State var authorizationAlertMessage = ""
+
+    @StateObject var searchCompleter = LocationSearchCompleter()
+
+    let minRadius: Double = 50
+    let maxRadius: Double = 500
+
+    public init(locationReminder: Binding<TCLocationReminder?>) {
+        _locationReminder = locationReminder
+
+        if let existing = locationReminder.wrappedValue {
+            _selectedLocation = State(initialValue: existing.coordinate)
+            _selectedLocationName = State(initialValue: existing.locationName)
+            _radius = State(initialValue: existing.radius)
+            _triggerOnArrival = State(initialValue: existing.triggerOnArrival)
+            _triggerOnDeparture = State(initialValue: existing.triggerOnDeparture)
+            _cameraPosition = State(
+                initialValue: .region(
+                    MKCoordinateRegion(
+                        center: existing.coordinate,
+                        latitudinalMeters: existing.radius * 4,
+                        longitudinalMeters: existing.radius * 4
+                    )
+                )
+            )
+        }
+    }
+
+    public var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                searchBar
+                    .padding()
+
+                if isSearching && !searchResults.isEmpty {
+                    searchResultsList
+                } else {
+                    mapView
+                        .overlay(alignment: .bottom) {
+                            if selectedLocation != nil {
+                                locationConfigCard
+                            }
+                        }
+                }
+            }
+            .navigationTitle("Location Reminder")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        saveLocation()
+                    }
+                    .disabled(selectedLocation == nil)
+                    .bold()
+                }
+            }
+            .onAppear {
+                checkLocationAuthorization()
+            }
+            .onChange(of: searchCompleter.results) { _, newResults in
+                searchResults = newResults
+            }
+            .alert("Location Access", isPresented: $showAuthorizationAlert) {
+                Button("Open Settings") {
+                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                        UIApplication.shared.open(url)
+                    }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text(authorizationAlertMessage)
+            }
+        }
+    }
+}

--- a/taskchamp/Sources/View/Components/LocationReminderButton.swift
+++ b/taskchamp/Sources/View/Components/LocationReminderButton.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import taskchampShared
+
+public struct LocationReminderButton: View {
+    @Binding var locationReminder: TCLocationReminder?
+    let action: () -> Void
+
+    public init(locationReminder: Binding<TCLocationReminder?>, action: @escaping () -> Void) {
+        _locationReminder = locationReminder
+        self.action = action
+    }
+
+    public var body: some View {
+        Button(action: action) {
+            HStack {
+                Image(systemName: locationReminder != nil ? "location.fill" : "location")
+                    .foregroundColor(locationReminder != nil ? .blue : .secondary)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    if let reminder = locationReminder {
+                        Text(reminder.locationName)
+                            .foregroundColor(.primary)
+                        HStack(spacing: 4) {
+                            Text(triggerDescription(for: reminder))
+                            Text("\(Int(reminder.radius))m radius")
+                        }
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    } else {
+                        Text("Add Location")
+                            .foregroundColor(.primary)
+                        Text("Get reminded at a specific place")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                Spacer()
+
+                if locationReminder != nil {
+                    Button {
+                        withAnimation {
+                            locationReminder = nil
+                        }
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                } else {
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func triggerDescription(for reminder: TCLocationReminder) -> String {
+        if reminder.triggerOnArrival && reminder.triggerOnDeparture {
+            return "Arrive & Leave"
+        } else if reminder.triggerOnArrival {
+            return "Arrive"
+        } else if reminder.triggerOnDeparture {
+            return "Leave"
+        }
+        return ""
+    }
+}

--- a/taskchamp/Sources/View/CreateTaskView.swift
+++ b/taskchamp/Sources/View/CreateTaskView.swift
@@ -30,6 +30,7 @@ public struct CreateTaskView: View, UseKeyboardToolbar {
     @State private var showTagPopover = false
     @State private var showLocationPicker = false
     @State private var locationReminder: TCLocationReminder?
+    @State private var criticalAlert: TCCriticalAlert?
     @State private var isShowingAlert = false
     @State private var alertTitle = ""
     @State private var alertMessage = ""
@@ -178,6 +179,10 @@ public struct CreateTaskView: View, UseKeyboardToolbar {
                         showTagPopover = true
                     }
                 }
+                CriticalAlertSettingsView(
+                    criticalAlert: $criticalAlert,
+                    hasDueDate: $didSetDate
+                )
                 Section {
                     LocationReminderButton(locationReminder: $locationReminder) {
                         showLocationPicker = true
@@ -212,7 +217,8 @@ public struct CreateTaskView: View, UseKeyboardToolbar {
                             priority: priority == .none ? nil : priority,
                             due: finalDate,
                             tags: tags.isEmpty ? nil : tags,
-                            locationReminder: locationReminder
+                            locationReminder: locationReminder,
+                            criticalAlert: criticalAlert
                         )
 
                         do {

--- a/taskchamp/Sources/View/CreateTaskView.swift
+++ b/taskchamp/Sources/View/CreateTaskView.swift
@@ -28,6 +28,8 @@ public struct CreateTaskView: View, UseKeyboardToolbar {
 
     @State private var showPaywall = false
     @State private var showTagPopover = false
+    @State private var showLocationPicker = false
+    @State private var locationReminder: TCLocationReminder?
     @State private var isShowingAlert = false
     @State private var alertTitle = ""
     @State private var alertMessage = ""
@@ -176,6 +178,13 @@ public struct CreateTaskView: View, UseKeyboardToolbar {
                         showTagPopover = true
                     }
                 }
+                Section {
+                    LocationReminderButton(locationReminder: $locationReminder) {
+                        showLocationPicker = true
+                    }
+                } header: {
+                    Text("Location Reminder")
+                }
             }.toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Done") {
@@ -202,7 +211,8 @@ public struct CreateTaskView: View, UseKeyboardToolbar {
                             status: status,
                             priority: priority == .none ? nil : priority,
                             due: finalDate,
-                            tags: tags.isEmpty ? nil : tags
+                            tags: tags.isEmpty ? nil : tags,
+                            locationReminder: locationReminder
                         )
 
                         do {
@@ -212,6 +222,9 @@ public struct CreateTaskView: View, UseKeyboardToolbar {
                             }
                             NotificationService.shared.requestAuthorization()
                             NotificationService.shared.createReminderForTask(task: task)
+                            if task.hasLocationReminder {
+                                LocationService.shared.startMonitoringRegion(for: task)
+                            }
                             dismiss()
                         } catch {
                             isShowingAlert = true
@@ -283,6 +296,9 @@ public struct CreateTaskView: View, UseKeyboardToolbar {
             }
             .navigationDestination(isPresented: $showTagPopover) {
                 AddTagView(selectedTags: $tags)
+            }
+            .sheet(isPresented: $showLocationPicker) {
+                LocationPickerView(locationReminder: $locationReminder)
             }
             .navigationTitle("New Task")
             .navigationBarTitleDisplayMode(.inline)

--- a/taskchamp/Sources/View/CriticalAlertGlobalSettingsView.swift
+++ b/taskchamp/Sources/View/CriticalAlertGlobalSettingsView.swift
@@ -1,0 +1,200 @@
+import SwiftUI
+import taskchampShared
+
+/// Global settings view for critical alerts.
+/// Shows authorization status, master toggle, and default volume preset.
+struct CriticalAlertGlobalSettingsView: View {
+    @Environment(\.dismiss) var dismiss
+    @Environment(\.openURL) private var openURL
+
+    @State private var criticalAlertsEnabled: Bool = true
+    @State private var defaultVolumePreset: TCCriticalAlertVolumePreset = .full
+    @State private var authorizationStatus: CriticalAlertAuthorizationStatus = .notDetermined
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    HStack {
+                        Text("Authorization Status")
+                        Spacer()
+                        statusBadge(for: authorizationStatus)
+                    }
+
+                    if authorizationStatus == .denied {
+                        Button {
+                            openSystemSettings()
+                        } label: {
+                            Label("Open Settings", systemImage: "gear")
+                        }
+                    } else if authorizationStatus == .notDetermined {
+                        Button {
+                            requestAuthorization()
+                        } label: {
+                            Label("Request Permission", systemImage: "bell.badge")
+                        }
+                    }
+                } header: {
+                    Text("Permission")
+                } footer: {
+                    if authorizationStatus == .denied {
+                        Text("Critical alerts are denied. Enable them in System Settings > Notifications > Taskchamp.")
+                    } else if authorizationStatus == .authorized {
+                        Text("Critical alerts can bypass Do Not Disturb and silent mode.")
+                    } else {
+                        // swiftlint:disable:next line_length
+                        Text("Critical alerts require special permission to bypass Do Not Disturb. Note: Production apps require Apple approval.")
+                    }
+                }
+
+                Section {
+                    Toggle(isOn: $criticalAlertsEnabled) {
+                        Label {
+                            Text("Enable Critical Alerts")
+                        } icon: {
+                            Image(systemName: "bell.badge.fill")
+                                .foregroundStyle(criticalAlertsEnabled ? .red : .secondary)
+                        }
+                    }
+                    .disabled(authorizationStatus != .authorized)
+                    .onChange(of: criticalAlertsEnabled) { _, newValue in
+                        NotificationService.shared.criticalAlertsEnabled = newValue
+                    }
+                } header: {
+                    Text("Global Toggle")
+                } footer: {
+                    Text("When disabled, all critical alerts will be delivered as regular notifications.")
+                }
+
+                Section {
+                    Picker("Default Volume", selection: $defaultVolumePreset) {
+                        ForEach(TCCriticalAlertVolumePreset.allCases, id: \.self) { preset in
+                            Text(preset.displayName).tag(preset)
+                        }
+                    }
+                    .disabled(authorizationStatus != .authorized || !criticalAlertsEnabled)
+                    .onChange(of: defaultVolumePreset) { _, newValue in
+                        NotificationService.shared.defaultCriticalAlertVolumePreset = newValue
+                    }
+                } header: {
+                    Text("Default Volume Preset")
+                } footer: {
+                    Text("This volume preset will be used as the default when creating new critical alerts.")
+                }
+
+                Section {
+                    VStack(alignment: .leading, spacing: 12) {
+                        InfoRow(
+                            icon: "exclamationmark.triangle.fill",
+                            iconColor: .orange,
+                            title: "What are Critical Alerts?",
+                            // swiftlint:disable:next line_length
+                            description: "Critical alerts play sound even when your device is muted or in Do Not Disturb mode."
+                        )
+                        InfoRow(
+                            icon: "bell.badge.fill",
+                            iconColor: .red,
+                            title: "When to Use",
+                            description: "Use critical alerts for time-sensitive reminders that you cannot miss."
+                        )
+                        InfoRow(
+                            icon: "speaker.wave.3.fill",
+                            iconColor: .blue,
+                            title: "Volume Control",
+                            description: "You can adjust the volume for each critical alert independently."
+                        )
+                    }
+                    .padding(.vertical, 4)
+                } header: {
+                    Text("About Critical Alerts")
+                }
+            }
+            .navigationTitle("Critical Alerts")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                    .bold()
+                }
+            }
+            .onAppear {
+                loadCurrentSettings()
+            }
+            .onReceive(
+                NotificationCenter.default.publisher(for: .TCCriticalAlertAuthorizationChanged)
+            ) { notification in
+                if let status = notification.object as? CriticalAlertAuthorizationStatus {
+                    authorizationStatus = status
+                }
+            }
+        }
+    }
+
+    private func loadCurrentSettings() {
+        criticalAlertsEnabled = NotificationService.shared.criticalAlertsEnabled
+        defaultVolumePreset = NotificationService.shared.defaultCriticalAlertVolumePreset
+        authorizationStatus = NotificationService.shared.criticalAlertStatus
+    }
+
+    private func requestAuthorization() {
+        NotificationService.shared.requestCriticalAlertAuthorization { _, _ in
+            Task { @MainActor in
+                await NotificationService.shared.updateCriticalAlertStatus()
+            }
+        }
+    }
+
+    private func openSystemSettings() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            openURL(url)
+        }
+    }
+
+    @ViewBuilder
+    private func statusBadge(for status: CriticalAlertAuthorizationStatus) -> some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(statusColor(for: status))
+                .frame(width: 8, height: 8)
+            Text(status.displayName)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func statusColor(for status: CriticalAlertAuthorizationStatus) -> Color {
+        switch status {
+        case .authorized:
+            return .green
+        case .denied:
+            return .red
+        case .notDetermined:
+            return .orange
+        }
+    }
+}
+
+private struct InfoRow: View {
+    let icon: String
+    let iconColor: Color
+    let title: String
+    let description: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .foregroundStyle(iconColor)
+                .frame(width: 24)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Text(description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}

--- a/taskchamp/Sources/View/EditTaskView-Ext.swift
+++ b/taskchamp/Sources/View/EditTaskView-Ext.swift
@@ -115,7 +115,8 @@ extension EditTaskView {
             priority: priority == .none ? nil : priority,
             due: finalDate,
             tags: tags,
-            locationReminder: locationReminder
+            locationReminder: locationReminder,
+            criticalAlert: criticalAlert
         )
 
         do {

--- a/taskchamp/Sources/View/EditTaskView.swift
+++ b/taskchamp/Sources/View/EditTaskView.swift
@@ -23,6 +23,8 @@ public struct EditTaskView: View, UseKeyboardToolbar {
     @State var time: Date = .init()
 
     @State private var showTagPopover = false
+    @State private var showLocationPicker = false
+    @State var locationReminder: TCLocationReminder?
     @State var isShowingAlert = false
     @State var isShowingObsidianSettings = false
     @State var alertTitle = ""
@@ -44,7 +46,8 @@ public struct EditTaskView: View, UseKeyboardToolbar {
                 date: didSetDate ? due : nil,
                 time: didSetTime ? time : nil
             ) ||
-            task.tags ?? [] != tags
+            task.tags ?? [] != tags ||
+            task.locationReminder != locationReminder
     }
 
     init(task: TCTask) {
@@ -53,6 +56,7 @@ public struct EditTaskView: View, UseKeyboardToolbar {
         status = task.status
         priority = task.priority ?? .none
         tags = task.tags ?? []
+        locationReminder = task.locationReminder
         if let due = task.due {
             didSetDate = true
             didSetTime = true
@@ -132,6 +136,13 @@ public struct EditTaskView: View, UseKeyboardToolbar {
                 AddTagButton(tags: $tags) {
                     showTagPopover = true
                 }
+            }
+            Section {
+                LocationReminderButton(locationReminder: $locationReminder) {
+                    showLocationPicker = true
+                }
+            } header: {
+                Text("Location Reminder")
             }
             Section {
                 Button(action: {
@@ -236,6 +247,9 @@ public struct EditTaskView: View, UseKeyboardToolbar {
             NavigationStack {
                 ObsidianNoteView(taskNote: task.obsidianNote ?? "")
             }
+        }
+        .sheet(isPresented: $showLocationPicker) {
+            LocationPickerView(locationReminder: $locationReminder)
         }
         .navigationTitle(description)
     }

--- a/taskchamp/Sources/View/EditTaskView.swift
+++ b/taskchamp/Sources/View/EditTaskView.swift
@@ -25,6 +25,7 @@ public struct EditTaskView: View, UseKeyboardToolbar {
     @State private var showTagPopover = false
     @State private var showLocationPicker = false
     @State var locationReminder: TCLocationReminder?
+    @State var criticalAlert: TCCriticalAlert?
     @State var isShowingAlert = false
     @State var isShowingObsidianSettings = false
     @State var alertTitle = ""
@@ -47,7 +48,8 @@ public struct EditTaskView: View, UseKeyboardToolbar {
                 time: didSetTime ? time : nil
             ) ||
             task.tags ?? [] != tags ||
-            task.locationReminder != locationReminder
+            task.locationReminder != locationReminder ||
+            task.criticalAlert != criticalAlert
     }
 
     init(task: TCTask) {
@@ -57,6 +59,7 @@ public struct EditTaskView: View, UseKeyboardToolbar {
         priority = task.priority ?? .none
         tags = task.tags ?? []
         locationReminder = task.locationReminder
+        criticalAlert = task.criticalAlert
         if let due = task.due {
             didSetDate = true
             didSetTime = true
@@ -137,6 +140,10 @@ public struct EditTaskView: View, UseKeyboardToolbar {
                     showTagPopover = true
                 }
             }
+            CriticalAlertSettingsView(
+                criticalAlert: $criticalAlert,
+                hasDueDate: $didSetDate
+            )
             Section {
                 LocationReminderButton(locationReminder: $locationReminder) {
                     showLocationPicker = true

--- a/taskchamp/Sources/View/TaskListView.swift
+++ b/taskchamp/Sources/View/TaskListView.swift
@@ -22,6 +22,7 @@ public struct TaskListView: View {
     @State var isShowingFilterView = false
     @State var isShowingObsidianSettings = false
     @State var isShowingSyncSettings = false
+    @State var isShowingCriticalAlertSettings = false
     @State var sortType: TasksHelper.TCSortType = .init(
         rawValue: UserDefaultsManager.standard
             .getValue(forKey: .sortType) ?? TasksHelper.TCSortType.defaultSort.rawValue
@@ -222,6 +223,9 @@ public struct TaskListView: View {
                     Button("Obsidian Settings") {
                         isShowingObsidianSettings.toggle()
                     }
+                    Button("Critical Alerts") {
+                        isShowingCriticalAlertSettings.toggle()
+                    }
                     Menu("Sort by") {
                         sortButton(sortType: .defaultSort)
                         sortButton(sortType: .date)
@@ -289,6 +293,9 @@ public struct TaskListView: View {
                 isShowingSyncServiceModal: $isShowingSyncSettings,
                 selectedSyncType: $selectedSyncType
             )
+        }
+        .sheet(isPresented: $isShowingCriticalAlertSettings) {
+            CriticalAlertGlobalSettingsView()
         }
         .navigationDestination(for: TCTask.self) { task in
             EditTaskView(task: task)

--- a/taskchampShared/Sources/Models/TCCriticalAlert.swift
+++ b/taskchampShared/Sources/Models/TCCriticalAlert.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Represents the volume preset options for critical alerts
+public enum TCCriticalAlertVolumePreset: String, Codable, Hashable, CaseIterable {
+    case full = "100"
+    case threeQuarter = "75"
+    case half = "50"
+    case quarter = "25"
+    case custom = "custom"
+
+    public var displayName: String {
+        switch self {
+        case .full:
+            return "100%"
+        case .threeQuarter:
+            return "75%"
+        case .half:
+            return "50%"
+        case .quarter:
+            return "25%"
+        case .custom:
+            return "Custom"
+        }
+    }
+
+    public var volumeValue: Float {
+        switch self {
+        case .full:
+            return 1.0
+        case .threeQuarter:
+            return 0.75
+        case .half:
+            return 0.5
+        case .quarter:
+            return 0.25
+        case .custom:
+            return 1.0
+        }
+    }
+}
+
+/// Represents critical alert settings for a task reminder
+public struct TCCriticalAlert: Codable, Hashable, Equatable {
+    public var isEnabled: Bool
+    public var volumePreset: TCCriticalAlertVolumePreset
+    public var customVolume: Float
+
+    public init(
+        isEnabled: Bool = false,
+        volumePreset: TCCriticalAlertVolumePreset = .full,
+        customVolume: Float = 1.0
+    ) {
+        self.isEnabled = isEnabled
+        self.volumePreset = volumePreset
+        self.customVolume = max(0.1, min(1.0, customVolume))
+    }
+
+    /// Returns the effective volume based on preset or custom value
+    public var effectiveVolume: Float {
+        if volumePreset == .custom {
+            return customVolume
+        }
+        return volumePreset.volumeValue
+    }
+}

--- a/taskchampShared/Sources/Services/LocationSearchCompleter.swift
+++ b/taskchampShared/Sources/Services/LocationSearchCompleter.swift
@@ -1,0 +1,34 @@
+import MapKit
+import SwiftUI
+
+public class LocationSearchCompleter: NSObject, ObservableObject {
+    @Published public var results: [MKLocalSearchCompletion] = []
+
+    private let completer = MKLocalSearchCompleter()
+
+    override public init() {
+        super.init()
+        completer.delegate = self
+        completer.resultTypes = [.address, .pointOfInterest]
+    }
+
+    public func search(query: String) {
+        guard !query.isEmpty else {
+            results = []
+            return
+        }
+        completer.queryFragment = query
+    }
+}
+
+extension LocationSearchCompleter: MKLocalSearchCompleterDelegate {
+    public func completerDidUpdateResults(_ completer: MKLocalSearchCompleter) {
+        DispatchQueue.main.async {
+            self.results = completer.results
+        }
+    }
+
+    public func completer(_: MKLocalSearchCompleter, didFailWithError error: Error) {
+        print("Search completer error: \(error.localizedDescription)")
+    }
+}

--- a/taskchampShared/Sources/Services/LocationService.swift
+++ b/taskchampShared/Sources/Services/LocationService.swift
@@ -1,0 +1,237 @@
+import CoreLocation
+import Foundation
+import UserNotifications
+
+public struct TCLocationReminder: Codable, Hashable, Equatable {
+    public var locationName: String
+    public var latitude: Double
+    public var longitude: Double
+    public var radius: Double
+    public var triggerOnArrival: Bool
+    public var triggerOnDeparture: Bool
+
+    public init(
+        locationName: String,
+        latitude: Double,
+        longitude: Double,
+        radius: Double = 50,
+        triggerOnArrival: Bool = true,
+        triggerOnDeparture: Bool = false
+    ) {
+        self.locationName = locationName
+        self.latitude = latitude
+        self.longitude = longitude
+        self.radius = radius
+        self.triggerOnArrival = triggerOnArrival
+        self.triggerOnDeparture = triggerOnDeparture
+    }
+
+    public var coordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+}
+
+public enum LocationAuthorizationStatus {
+    case notDetermined
+    case denied
+    case authorizedWhenInUse
+    case authorizedAlways
+    case restricted
+
+    public var canMonitorRegions: Bool {
+        self == .authorizedAlways
+    }
+
+    public var isAuthorized: Bool {
+        self == .authorizedWhenInUse || self == .authorizedAlways
+    }
+}
+
+public class LocationService: NSObject {
+    public static let shared = LocationService()
+
+    private let locationManager = CLLocationManager()
+    private let notificationCenter = UNUserNotificationCenter.current()
+    private let maxMonitoredRegions = 20
+
+    public var authorizationStatus: LocationAuthorizationStatus {
+        switch locationManager.authorizationStatus {
+        case .notDetermined:
+            return .notDetermined
+        case .denied:
+            return .denied
+        case .authorizedWhenInUse:
+            return .authorizedWhenInUse
+        case .authorizedAlways:
+            return .authorizedAlways
+        case .restricted:
+            return .restricted
+        @unknown default:
+            return .notDetermined
+        }
+    }
+
+    public var canMonitorRegions: Bool {
+        CLLocationManager.isMonitoringAvailable(for: CLCircularRegion.self)
+            && authorizationStatus.canMonitorRegions
+    }
+
+    public var currentMonitoredRegionCount: Int {
+        locationManager.monitoredRegions.count
+    }
+
+    override private init() {
+        super.init()
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+    }
+
+    public func requestWhenInUseAuthorization() {
+        locationManager.requestWhenInUseAuthorization()
+    }
+
+    public func requestAlwaysAuthorization() {
+        locationManager.requestAlwaysAuthorization()
+    }
+
+    public func startMonitoringRegion(for task: TCTask) {
+        guard let locationReminder = task.locationReminder else {
+            return
+        }
+
+        guard canMonitorRegions else {
+            print("Location monitoring not available or not authorized")
+            return
+        }
+
+        if currentMonitoredRegionCount >= maxMonitoredRegions {
+            print("Maximum monitored regions reached (\(maxMonitoredRegions))")
+            return
+        }
+
+        let region = CLCircularRegion(
+            center: locationReminder.coordinate,
+            radius: min(locationReminder.radius, locationManager.maximumRegionMonitoringDistance),
+            identifier: task.uuid
+        )
+
+        region.notifyOnEntry = locationReminder.triggerOnArrival
+        region.notifyOnExit = locationReminder.triggerOnDeparture
+
+        locationManager.startMonitoring(for: region)
+    }
+
+    public func stopMonitoringRegion(for taskUuid: String) {
+        for region in locationManager.monitoredRegions where region.identifier == taskUuid {
+            locationManager.stopMonitoring(for: region)
+            break
+        }
+    }
+
+    public func stopMonitoringAllRegions() {
+        for region in locationManager.monitoredRegions {
+            locationManager.stopMonitoring(for: region)
+        }
+    }
+
+    public func reregisterGeofences(for tasks: [TCTask]) {
+        stopMonitoringAllRegions()
+
+        let tasksWithLocation = tasks
+            .filter { $0.locationReminder != nil && $0.status == .pending }
+            .sorted { task1, task2 in
+                if let due1 = task1.due, let due2 = task2.due {
+                    return due1 < due2
+                } else if task1.due != nil {
+                    return true
+                } else {
+                    return false
+                }
+            }
+
+        let tasksToMonitor = Array(tasksWithLocation.prefix(maxMonitoredRegions))
+
+        for task in tasksToMonitor {
+            startMonitoringRegion(for: task)
+        }
+    }
+
+    public func isMonitoring(taskUuid: String) -> Bool {
+        locationManager.monitoredRegions.contains { $0.identifier == taskUuid }
+    }
+
+    private func createLocationNotification(for region: CLRegion, isEntering: Bool) {
+        guard let circularRegion = region as? CLCircularRegion else {
+            return
+        }
+
+        let taskUuid = circularRegion.identifier
+
+        Task { @MainActor in
+            do {
+                let task = try TaskchampionService.shared.getTask(uuid: taskUuid)
+
+                guard task.status == .pending else {
+                    self.stopMonitoringRegion(for: taskUuid)
+                    return
+                }
+
+                guard let locationReminder = task.locationReminder else {
+                    return
+                }
+
+                let content = UNMutableNotificationContent()
+                content.title = task.description
+
+                let triggerType = isEntering ? "Arrived at" : "Left"
+                content.body = "\(triggerType) \(locationReminder.locationName)"
+                content.sound = .default
+                content.interruptionLevel = .timeSensitive
+                content.userInfo = ["deepLink": task.url.description]
+
+                let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+
+                let request = UNNotificationRequest(
+                    identifier: "location-\(taskUuid)-\(Date().timeIntervalSince1970)",
+                    content: content,
+                    trigger: trigger
+                )
+
+                self.notificationCenter.add(request)
+            } catch {
+                print("Failed to get task for location notification: \(error)")
+            }
+        }
+    }
+}
+
+// MARK: - CLLocationManagerDelegate
+
+extension LocationService: CLLocationManagerDelegate {
+    public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        NotificationCenter.default.post(
+            name: .TCLocationAuthorizationChanged,
+            object: authorizationStatus
+        )
+    }
+
+    public func locationManager(_: CLLocationManager, didEnterRegion region: CLRegion) {
+        createLocationNotification(for: region, isEntering: true)
+    }
+
+    public func locationManager(_: CLLocationManager, didExitRegion region: CLRegion) {
+        createLocationNotification(for: region, isEntering: false)
+    }
+
+    public func locationManager(_: CLLocationManager, monitoringDidFailFor region: CLRegion?, withError error: Error) {
+        print("Region monitoring failed for \(region?.identifier ?? "unknown"): \(error.localizedDescription)")
+    }
+
+    public func locationManager(_: CLLocationManager, didFailWithError error: Error) {
+        print("Location manager failed: \(error.localizedDescription)")
+    }
+}
+
+public extension NSNotification.Name {
+    static let TCLocationAuthorizationChanged = NSNotification.Name("TCLocationAuthorizationChanged")
+}

--- a/taskchampShared/Sources/Services/LocationService.swift
+++ b/taskchampShared/Sources/Services/LocationService.swift
@@ -185,9 +185,17 @@ public class LocationService: NSObject {
 
                 let triggerType = isEntering ? "Arrived at" : "Left"
                 content.body = "\(triggerType) \(locationReminder.locationName)"
-                content.sound = .default
-                content.interruptionLevel = .timeSensitive
                 content.userInfo = ["deepLink": task.url.description]
+
+                // Configure sound and interruption level based on critical alert settings
+                if task.hasCriticalAlert && NotificationService.shared.canUseCriticalAlerts {
+                    let volume = task.criticalAlert?.effectiveVolume ?? 1.0
+                    content.sound = UNNotificationSound.defaultCriticalSound(withAudioVolume: volume)
+                    content.interruptionLevel = .critical
+                } else {
+                    content.sound = .default
+                    content.interruptionLevel = .timeSensitive
+                }
 
                 let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
 

--- a/taskchampShared/Sources/Services/NotificationService.swift
+++ b/taskchampShared/Sources/Services/NotificationService.swift
@@ -1,13 +1,66 @@
 import Foundation
 import UserNotifications
 
+/// Represents the authorization status for critical alerts
+public enum CriticalAlertAuthorizationStatus: String {
+    case notDetermined
+    case authorized
+    case denied
+
+    public var displayName: String {
+        switch self {
+        case .notDetermined:
+            return "Not Determined"
+        case .authorized:
+            return "Authorized"
+        case .denied:
+            return "Denied"
+        }
+    }
+}
+
 public class NotificationService: NSObject {
     public static let shared = NotificationService()
     let center = UNUserNotificationCenter.current()
 
+    /// Cached authorization status for critical alerts
+    public private(set) var criticalAlertStatus: CriticalAlertAuthorizationStatus = .notDetermined
+
+    /// Global setting to enable/disable critical alerts
+    public var criticalAlertsEnabled: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: "criticalAlertsEnabled")
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: "criticalAlertsEnabled")
+        }
+    }
+
+    /// Default volume preset for new critical alerts
+    public var defaultCriticalAlertVolumePreset: TCCriticalAlertVolumePreset {
+        get {
+            if let rawValue = UserDefaults.standard.string(forKey: "defaultCriticalAlertVolumePreset"),
+                let preset = TCCriticalAlertVolumePreset(rawValue: rawValue) {
+                return preset
+            }
+            return .half
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: "defaultCriticalAlertVolumePreset")
+        }
+    }
+
     override private init() {
         super.init()
         center.delegate = self
+        // Initialize critical alerts as enabled by default
+        if UserDefaults.standard.object(forKey: "criticalAlertsEnabled") == nil {
+            criticalAlertsEnabled = true
+        }
+        // Check current authorization status
+        Task {
+            await updateCriticalAlertStatus()
+        }
     }
 
     public static func defaultRequestCallback(success: Bool, error: (any Error)?) {
@@ -18,6 +71,27 @@ public class NotificationService: NSObject {
         }
     }
 
+    /// Updates the cached critical alert authorization status
+    @MainActor
+    public func updateCriticalAlertStatus() async {
+        let settings = await center.notificationSettings()
+        switch settings.criticalAlertSetting {
+        case .enabled:
+            criticalAlertStatus = .authorized
+        case .disabled:
+            criticalAlertStatus = .denied
+        case .notSupported:
+            criticalAlertStatus = .notDetermined
+        @unknown default:
+            criticalAlertStatus = .notDetermined
+        }
+        NotificationCenter.default.post(
+            name: .TCCriticalAlertAuthorizationChanged,
+            object: criticalAlertStatus
+        )
+    }
+
+    /// Requests authorization for notifications including critical alerts
     public func requestAuthorization(
         completionHandler: @escaping (Bool, (any Error)?)
             -> Void = defaultRequestCallback
@@ -26,10 +100,39 @@ public class NotificationService: NSObject {
             options: [
                 .alert,
                 .badge,
-                .sound
+                .sound,
+                .criticalAlert
             ],
-            completionHandler: completionHandler
-        )
+        ) { [weak self] success, error in
+            completionHandler(success, error)
+            Task { @MainActor in
+                await self?.updateCriticalAlertStatus()
+            }
+        }
+    }
+
+    /// Requests authorization for critical alerts specifically
+    public func requestCriticalAlertAuthorization(
+        completionHandler: @escaping (Bool, (any Error)?) -> Void = defaultRequestCallback
+    ) {
+        UNUserNotificationCenter.current().requestAuthorization(
+            options: [
+                .alert,
+                .badge,
+                .sound,
+                .criticalAlert
+            ]
+        ) { [weak self] success, error in
+            completionHandler(success, error)
+            Task { @MainActor in
+                await self?.updateCriticalAlertStatus()
+            }
+        }
+    }
+
+    /// Checks if critical alerts can be used (authorized and enabled)
+    public var canUseCriticalAlerts: Bool {
+        criticalAlertStatus == .authorized && criticalAlertsEnabled
     }
 
     public func removeAllNotifications() {
@@ -63,9 +166,17 @@ public class NotificationService: NSObject {
 
         content.title = task.description
         content.body = task.localDateShort
-        content.sound = UNNotificationSound.default
-        content.interruptionLevel = .timeSensitive
         content.userInfo = ["deepLink": task.url.description]
+
+        // Configure sound and interruption level based on critical alert settings
+        if task.hasCriticalAlert && canUseCriticalAlerts {
+            let volume = task.criticalAlert?.effectiveVolume ?? 1.0
+            content.sound = UNNotificationSound.defaultCriticalSound(withAudioVolume: volume)
+            content.interruptionLevel = .critical
+        } else {
+            content.sound = UNNotificationSound.default
+            content.interruptionLevel = .timeSensitive
+        }
 
         let trigger = UNCalendarNotificationTrigger(
             dateMatching: curDateComponents,
@@ -97,4 +208,5 @@ extension NotificationService: UNUserNotificationCenterDelegate {
 
 public extension NSNotification.Name {
     static let TCTappedDeepLinkNotification = NSNotification.Name("TCTappedDeepLinkNotification")
+    static let TCCriticalAlertAuthorizationChanged = NSNotification.Name("TCCriticalAlertAuthorizationChanged")
 }

--- a/taskchampShared/Sources/Services/TaskchampionService.swift
+++ b/taskchampShared/Sources/Services/TaskchampionService.swift
@@ -228,6 +228,10 @@ public class TaskchampionService {
             annotations = annotations ?? RustVec<Annotation>()
             annotations?.push(value: annotation)
         }
+        if let annotation = task.rustAnnotationFromCriticalAlert {
+            annotations = annotations ?? RustVec<Annotation>()
+            annotations?.push(value: annotation)
+        }
 
         let task = replica.update_task(
             task.uuid.intoRustString(),
@@ -278,13 +282,17 @@ public class TaskchampionService {
             throw TCError.genericError("Failed to create task")
         }
 
-        // Add annotations if present (location reminder or obsidian note)
+        // Add annotations if present (location reminder, obsidian note, or critical alert)
         var annotations: RustVec<Annotation>?
         if let annotation = task.rustAnnotationFromObsidianNote {
             annotations = annotations ?? RustVec<Annotation>()
             annotations?.push(value: annotation)
         }
         if let annotation = task.rustAnnotationFromLocationReminder {
+            annotations = annotations ?? RustVec<Annotation>()
+            annotations?.push(value: annotation)
+        }
+        if let annotation = task.rustAnnotationFromCriticalAlert {
             annotations = annotations ?? RustVec<Annotation>()
             annotations?.push(value: annotation)
         }


### PR DESCRIPTION
## Summary

This PR adds two related notification features:

### Location-Based Reminders
- Geofence monitoring for task reminders triggered by arrival/departure
- Location search with Apple Maps integration
- Configurable radius (50m to 500m) and trigger conditions
- Respects iOS 20-region monitoring limit with smart prioritization by due date
- Authorization flow handling for all location permission states

### Critical Alerts
- Critical alerts bypass Do Not Disturb and silent mode for important reminders
- Volume presets (100%, 75%, 50%, 25%) plus custom slider option
- Per-task toggle available when a due date is set
- Global settings page accessible from menu (Critical Alerts)
- Red bell indicator on task list for critical alert items
- Works with both time-based and location-based reminders

### Implementation Details

**Location Reminders:**
- `LocationService`: CLLocationManager, geofence monitoring, notifications
- `LocationPickerView`: MapKit UI for selecting locations with search
- `TCTask.locationReminder`: Stored as Taskchampion annotation

**Critical Alerts:**
- `TCCriticalAlert` model with volume preset and custom volume
- `CriticalAlertSettingsView`: Per-task configuration component
- `CriticalAlertGlobalSettingsView`: Settings page for authorization and defaults
- `NotificationService`: Authorization tracking and critical sound delivery

### Requirements

- Location reminders require "Always" location authorization
- Critical alerts require the `com.apple.developer.usernotifications.critical-alerts` entitlement (needs Apple approval for production distribution)

## Test Plan

- [ ] Verify location reminder creation with search and map selection
- [ ] Test geofence triggering for arrival and departure
- [ ] Verify critical alert toggle enables when due date is set
- [ ] Test volume presets and custom slider
- [ ] Confirm critical alert sounds play through silent mode
- [ ] Check red bell indicator appears on tasks with critical alerts enabled
- [ ] Test global settings page toggle and default volume preset

**Testing note:** These features have been verified in Xcode simulator. Real-world testing on physical devices is recommended, particularly for geofence accuracy and notification delivery in various device states.