### PR TITLE
feat: QoL with Quick Adds

### DIFF
--- a/Derived/Entitlements/taskchampShareExtension.entitlements
+++ b/Derived/Entitlements/taskchampShareExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.mav.taskchamp</string>
+	</array>
+</dict>
+</plist>

--- a/Derived/InfoPlists/taskchampShareExtension-Info.plist
+++ b/Derived/InfoPlists/taskchampShareExtension-Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Taskchamp</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>3.4</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+	</dict>
+</dict>
+</plist>

--- a/Project.swift
+++ b/Project.swift
@@ -49,7 +49,8 @@ let project = Project(
             dependencies: [
                 .external(name: "MarkdownUI"),
                 .target(name: "taskchampShared"),
-                .target(name: "taskchampWidget")
+                .target(name: "taskchampWidget"),
+                .target(name: "taskchampShareExtension")
             ]
         ),
         .target(
@@ -93,6 +94,35 @@ let project = Project(
                     "com.apple.security.application-groups": ["group.com.mav.taskchamp"]
                 ]
             ),
+            dependencies: [
+                .target(name: "taskchampShared")
+            ]
+        ),
+        .target(
+            name: "taskchampShareExtension",
+            destinations: .iOS,
+            product: .appExtension,
+            bundleId: "com.mav.taskchamp.taskchampShareExtension",
+            deploymentTargets: .iOS("17.0"),
+            infoPlist: .extendingDefault(with: [
+                "CFBundleDisplayName": "Taskchamp",
+                "NSExtension": [
+                    "NSExtensionPointIdentifier": "com.apple.share-services",
+                    "NSExtensionPrincipalClass": "$(PRODUCT_MODULE_NAME).ShareViewController",
+                    "NSExtensionAttributes": [
+                        "NSExtensionActivationRule": [
+                            "NSExtensionActivationSupportsText": true,
+                            "NSExtensionActivationSupportsWebURLWithMaxCount": 1,
+                            "NSExtensionActivationSupportsWebPageWithMaxCount": 1
+                        ]
+                    ]
+                ],
+                "CFBundleShortVersionString": "3.4"
+            ]),
+            sources: "taskchampShareExtension/Sources/**",
+            entitlements: .dictionary([
+                "com.apple.security.application-groups": ["group.com.mav.taskchamp"]
+            ]),
             dependencies: [
                 .target(name: "taskchampShared")
             ]

--- a/WhatToTest.txt
+++ b/WhatToTest.txt
@@ -1,4 +1,5 @@
 Recurring tasks read path 
-Widget filters
-Filter shortcuts
-
+Quick add using share sheet (text and URLs)
+New quick add widget for lock screen
+New shortcut for quick add (including prefill)
+Various Ui changes to buttons and description field

--- a/taskchamp/Sources/ContentView.swift
+++ b/taskchamp/Sources/ContentView.swift
@@ -19,6 +19,7 @@ public struct ContentView: View {
     @State private var selectedSyncType: TaskchampionService.SyncType?
     @State private var isShowingSyncServiceModal = false
     @State var isShowingCreateTaskView = false
+    @State var createTaskContent = ""
 
     public init() {
         UINavigationBar.appearance().largeTitleTextAttributes = [.foregroundColor: UIColor.tintColor]
@@ -69,6 +70,19 @@ public struct ContentView: View {
             let uuidString = url.pathComponents[1]
 
             if uuidString == "new" {
+                if let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+                   let contentParam = components.queryItems?.first(where: { $0.name == "content" })?.value,
+                   !contentParam.isEmpty
+                {
+                    createTaskContent = contentParam
+                } else if let pending: String = UserDefaultsManager.standard.getValue(forKey: .pendingNewTaskContent),
+                          !pending.isEmpty
+                {
+                    createTaskContent = pending
+                } else {
+                    createTaskContent = ""
+                }
+                UserDefaultsManager.standard.remove(forKey: .pendingNewTaskContent)
                 isShowingCreateTaskView = true
                 return
             }
@@ -88,7 +102,8 @@ public struct ContentView: View {
                 isShowingICloudAlert: $isShowingAlert,
                 selectedFilter: $selectedFilter,
                 selectedSyncType: $selectedSyncType,
-                isShowingCreateTaskView: $isShowingCreateTaskView
+                isShowingCreateTaskView: $isShowingCreateTaskView,
+                createTaskContent: $createTaskContent
             )
         }
         .onOpenURL { url in

--- a/taskchamp/Sources/Intents/OpenNewTaskIntent.swift
+++ b/taskchamp/Sources/Intents/OpenNewTaskIntent.swift
@@ -1,0 +1,31 @@
+import AppIntents
+import taskchampShared
+
+struct OpenNewTaskIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Quick Add"
+    static var description: IntentDescription = "Opens Taskchamp to create a new task."
+    static var openAppWhenRun: Bool = true
+
+    @Parameter(title: "Content", default: "")
+    var content: String
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        if !content.isEmpty {
+            UserDefaultsManager.standard.set(value: content, forKey: .pendingNewTaskContent)
+        }
+        var urlString = "taskchamp://task/new"
+        if !content.isEmpty,
+           let encoded = content.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        {
+            urlString += "?content=\(encoded)"
+        }
+        if let url = URL(string: urlString) {
+            NotificationCenter.default.post(
+                name: .TCTappedDeepLinkNotification,
+                object: url
+            )
+        }
+        return .result()
+    }
+}

--- a/taskchamp/Sources/Intents/TaskchampShortcuts.swift
+++ b/taskchamp/Sources/Intents/TaskchampShortcuts.swift
@@ -11,5 +11,15 @@ struct TaskchampShortcuts: AppShortcutsProvider {
             shortTitle: "Open Filter",
             systemImageName: "line.3.horizontal.decrease.circle"
         )
+        AppShortcut(
+            intent: OpenNewTaskIntent(),
+            phrases: [
+                "Quick add in \(.applicationName)",
+                "New task in \(.applicationName)",
+                "Add task in \(.applicationName)"
+            ],
+            shortTitle: "Open Quick Add",
+            systemImageName: "plus.circle.fill"
+        )
     }
 }

--- a/taskchamp/Sources/View/Cells/TaskCellView.swift
+++ b/taskchamp/Sources/View/Cells/TaskCellView.swift
@@ -6,8 +6,10 @@ public struct TaskCellView: View {
 
     public var body: some View {
         VStack {
-            HStack {
+            HStack(alignment: .top) {
                 Text(task.description)
+                    .lineLimit(2)
+                    .truncationMode(.tail)
                     .strikethrough(task.isCompleted || task.isDeleted, color: task.isDeleted ? .red : nil)
                     .foregroundStyle(task.isCompleted ? .secondary : task.isDeleted ? Color.red : .primary)
                 Spacer()

--- a/taskchamp/Sources/View/CreateTaskView.swift
+++ b/taskchamp/Sources/View/CreateTaskView.swift
@@ -231,7 +231,7 @@ public struct CreateTaskView: View, UseKeyboardToolbar {
                         }
                     }
                     .bold()
-                    .tint(.indigo)
+                    .tint(Color(asset: TaskchampAsset.Assets.accentColor))
                 }
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("Cancel") {

--- a/taskchamp/Sources/View/CreateTaskView.swift
+++ b/taskchamp/Sources/View/CreateTaskView.swift
@@ -183,7 +183,7 @@ public struct CreateTaskView: View, UseKeyboardToolbar {
                 }
             }.toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button("Done") {
+                    Button("Add") {
                         if description.isEmpty {
                             isShowingAlert = true
                             alertTitle = "Missing field"
@@ -226,9 +226,10 @@ public struct CreateTaskView: View, UseKeyboardToolbar {
                         }
                     }
                     .bold()
+                    .tint(.indigo)
                 }
                 ToolbarItem(placement: .navigationBarLeading) {
-                    Button("Back") {
+                    Button("Cancel") {
                         if hasUnsavedContent {
                             showDismissConfirmation = true
                         } else {

--- a/taskchamp/Sources/View/CreateTaskView.swift
+++ b/taskchamp/Sources/View/CreateTaskView.swift
@@ -7,6 +7,8 @@ public struct CreateTaskView: View, UseKeyboardToolbar {
     @Environment(StoreKitManager.self) var storeKit: StoreKitManager
     @Environment(GlobalState.self) var globalState: GlobalState
 
+    var initialContent: String = ""
+
     @State private var nlpInput = ""
     @State private var nlpPlaceholder =
         "New Task due:tomorrow at 1pm project:my-project prio:M +my-tag"
@@ -109,6 +111,9 @@ public struct CreateTaskView: View, UseKeyboardToolbar {
                             }
                         }
                         .onFirstAppear {
+                            if !initialContent.isEmpty {
+                                nlpInput = initialContent + " "
+                            }
                             focusedField = .nlp
                         }
                 } header: {

--- a/taskchamp/Sources/View/EditTaskView.swift
+++ b/taskchamp/Sources/View/EditTaskView.swift
@@ -170,7 +170,7 @@ public struct EditTaskView: View, UseKeyboardToolbar {
                 }
                 .disabled(!didChange)
                 .bold()
-                .tint(.indigo)
+                .tint(Color(asset: TaskchampAsset.Assets.accentColor))
             }
             ToolbarItemGroup(placement: .bottomBar) {
                 Button {

--- a/taskchamp/Sources/View/EditTaskView.swift
+++ b/taskchamp/Sources/View/EditTaskView.swift
@@ -95,10 +95,17 @@ public struct EditTaskView: View, UseKeyboardToolbar {
     public var body: some View {
         Form {
             Section {
-                TextEditor(text: $description)
-                    .focused($focusedField, equals: .description)
-                    .bold()
-                    .frame(minHeight: 40)
+                ZStack(alignment: .topLeading) {
+                    Text(description.isEmpty ? " " : description)
+                        .bold()
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 5)
+                        .opacity(0)
+                    TextEditor(text: $description)
+                        .focused($focusedField, equals: .description)
+                        .bold()
+                }
+                .frame(minHeight: 40)
                 TextField("Project", text: $project)
                     .focused($focusedField, equals: .project)
             } header: {
@@ -163,6 +170,7 @@ public struct EditTaskView: View, UseKeyboardToolbar {
                 }
                 .disabled(!didChange)
                 .bold()
+                .tint(.indigo)
             }
             ToolbarItemGroup(placement: .bottomBar) {
                 Button {

--- a/taskchamp/Sources/View/TaskListView.swift
+++ b/taskchamp/Sources/View/TaskListView.swift
@@ -13,6 +13,7 @@ public struct TaskListView: View {
     @Binding var selectedFilter: TCFilter
     @Binding var selectedSyncType: TaskchampionService.SyncType?
     @Binding var isShowingCreateTaskView: Bool
+    @Binding var createTaskContent: String
 
     @State var rebuildingCache = true
     @State var tasks: [TCTask] = []
@@ -31,13 +32,15 @@ public struct TaskListView: View {
         isShowingICloudAlert: Binding<Bool>,
         selectedFilter: Binding<TCFilter>,
         selectedSyncType: Binding<TaskchampionService.SyncType?>,
-        isShowingCreateTaskView: Binding<Bool>
+        isShowingCreateTaskView: Binding<Bool>,
+        createTaskContent: Binding<String>
     ) {
         UINavigationBar.appearance().largeTitleTextAttributes = [.foregroundColor: UIColor.tintColor]
         _isShowingICloudAlert = isShowingICloudAlert
         _selectedFilter = selectedFilter
         _selectedSyncType = selectedSyncType
         _isShowingCreateTaskView = isShowingCreateTaskView
+        _createTaskContent = createTaskContent
     }
 
     private func sortButton(sortType: TasksHelper.TCSortType) -> some View {
@@ -274,9 +277,10 @@ public struct TaskListView: View {
             updateTasks()
         }
         .sheet(isPresented: $isShowingCreateTaskView, onDismiss: {
+            createTaskContent = ""
             updateTasks()
         }, content: {
-            CreateTaskView()
+            CreateTaskView(initialContent: createTaskContent)
         })
         .sheet(isPresented: $isShowingFilterView) {
             AddFilterView(selectedFilter: $selectedFilter)

--- a/taskchampShareExtension/Sources/ShareAddTagView.swift
+++ b/taskchampShareExtension/Sources/ShareAddTagView.swift
@@ -1,0 +1,193 @@
+import SwiftData
+import SwiftUI
+import taskchampShared
+
+struct ShareAddTagView: View {
+    @Environment(\.modelContext) var modelContext
+    @Environment(\.dismiss) var dismiss
+    @Binding var selectedTags: [TCTag]
+
+    @Query var tags: [TCTag]
+
+    @State private var input = ""
+    @State private var showPopover = false
+    @State private var isShowingAlert = false
+    @State private var alertTitle = ""
+    @State private var alertMessage = ""
+
+    @FocusState private var isFocused: Bool
+
+    private var searchTags: [TCTag] {
+        if input.isEmpty { return tags }
+        return tags.filter { $0.name.lowercased().contains(input.lowercased()) }
+    }
+
+    private func onTapTag(_ tag: TCTag) -> Bool {
+        if tag.isSynthetic() {
+            alertTitle = "Synthetic tag"
+            alertMessage = "You cannot add or remove synthetic tags manually."
+            isShowingAlert = true
+            return false
+        }
+        if !tag.isValid() {
+            alertTitle = "Invalid tag"
+            alertMessage = "Please enter a valid tag"
+            isShowingAlert = true
+            return false
+        }
+        return true
+    }
+
+    let instructions: LocalizedStringKey = """
+    A Tag is a descriptor for a task, that is either present or absent, and can be used for filtering.
+
+    Valid tags must not contain whitespace or any of the characters in `+-*/(<>^! %=~`.
+
+    Tags composed of all uppercase letters are reserved for synthetic tags.
+
+    The first characters additionally cannot be a digit, and subsequent characters cannot be `:`
+    """
+
+    var body: some View {
+        Form {
+            Section {
+                TextField("newtag", text: $input)
+                    .font(.system(.body, design: .monospaced))
+                    .autocapitalization(.none)
+                    .autocorrectionDisabled()
+                    .focused($isFocused)
+                    .onAppear {
+                        isFocused = false
+                    }
+                    .submitLabel(.join)
+                    .onSubmit {
+                        withAnimation {
+                            if input.isEmpty {
+                                alertTitle = "Empty input"
+                                alertMessage = "Please enter a valid tag"
+                                isShowingAlert = true
+                                return
+                            }
+                            let newTag = TCTag.tagFactory(name: input)
+                            if !onTapTag(newTag) {
+                                return
+                            }
+                            selectedTags.append(newTag)
+                            if !tags.contains(where: { $0.name == newTag.name }) {
+                                modelContext.insert(newTag)
+                            }
+                            input = ""
+                            isFocused = false
+                        }
+                    }
+            } header: {
+                HStack {
+                    Text("Search or create a tag")
+                    Button {
+                        showPopover.toggle()
+                    } label: {
+                        Image(systemName: SFSymbols.questionmarkCircle.rawValue)
+                    }
+                    .popover(
+                        isPresented: $showPopover,
+                        attachmentAnchor: .point(.bottom)
+                    ) {
+                        ScrollView {
+                            VStack(alignment: .leading, spacing: 10) {
+                                Text(instructions)
+                                    .padding(.top)
+                            }
+                        }
+                        .textCase(nil)
+                        .frame(minHeight: 300)
+                        .padding()
+                        .presentationCompactAdaptation(.popover)
+                    }
+                }
+            }
+            Section(header: Text("Saved Tags")) {
+                if tags.isEmpty {
+                    ContentUnavailableView {
+                        Label("No tags", systemImage: "bolt.heart")
+                    } description: {
+                        Text("Add a new tag using the input above.")
+                    }
+                } else {
+                    ForEach(searchTags, id: \.name) { tag in
+                        Button {
+                            if !onTapTag(tag) {
+                                return
+                            }
+                            if selectedTags.contains(where: { $0.name == tag.name }) {
+                                selectedTags.removeAll { $0.name == tag.name }
+                                input = ""
+                                return
+                            }
+                            selectedTags.append(tag)
+                            input = ""
+                        } label: {
+                            HStack {
+                                Text(tag.name)
+                                    .font(.system(.body, design: .monospaced))
+                                if selectedTags.contains(where: { $0.name == tag.name }) {
+                                    Spacer()
+                                    Image(systemName: SFSymbols.checkmark.rawValue)
+                                }
+                            }
+                        }
+                        .disabled(tag.isSynthetic())
+                        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                            if !tag.isSynthetic() {
+                                Button(role: .destructive) {
+                                    withAnimation {
+                                        modelContext.delete(tag)
+                                        selectedTags.removeAll { $0.name == tag.name }
+                                    }
+                                } label: {
+                                    Label("Delete", systemImage: SFSymbols.trash.rawValue)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .alert(isPresented: $isShowingAlert) {
+            Alert(
+                title: Text(alertTitle),
+                message: Text(alertMessage),
+                dismissButton: .default(Text("OK"))
+            )
+        }
+        .toolbar {
+            ToolbarItem(placement: .keyboard) {
+                HStack {
+                    Spacer()
+                    Button(action: { isFocused = false }) {
+                        Label(
+                            "Dismiss keyboard",
+                            systemImage: SFSymbols.checkmark.rawValue
+                        )
+                    }
+                }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    dismiss()
+                } label: {
+                    Label("Done", systemImage: SFSymbols.checkmark.rawValue)
+                }
+            }
+        }
+        .navigationTitle("Add Tags")
+        .navigationBarTitleDisplayMode(.inline)
+        .animation(.default, value: tags)
+        .animation(.default, value: searchTags)
+        .animation(.default, value: selectedTags)
+        .onAppear {
+            for tag in selectedTags where !tags.contains(where: { $0.name == tag.name }) {
+                modelContext.insert(tag)
+            }
+        }
+    }
+}

--- a/taskchampShareExtension/Sources/ShareComposeView.swift
+++ b/taskchampShareExtension/Sources/ShareComposeView.swift
@@ -174,10 +174,11 @@ struct ShareComposeView: View {
             }
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button("Done") {
+                    Button("Add") {
                         createTask()
                     }
                     .bold()
+                    .tint(.indigo)
                 }
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("Cancel") {

--- a/taskchampShareExtension/Sources/ShareComposeView.swift
+++ b/taskchampShareExtension/Sources/ShareComposeView.swift
@@ -1,0 +1,483 @@
+import SwiftUI
+import taskchampShared
+
+struct ShareComposeView: View {
+    var sharedText: String?
+    var onComplete: () -> Void
+    var onCancel: () -> Void
+
+    @State private var nlpInput = ""
+    @State private var description = ""
+    @State private var project = ""
+    @State private var tags: [TCTag] = []
+    @State private var priority: TCTask.Priority = .none
+
+    @State private var didSetDate = false
+    @State private var didSetTime = false
+    @State private var isDateShowing = false
+    @State private var isTimeShowing = false
+    @State private var due: Date = .init()
+    @State private var time: Date = .init()
+
+    @State private var isShowingAlert = false
+    @State private var alertTitle = ""
+    @State private var alertMessage = ""
+    @State private var showDismissConfirmation = false
+    @State private var showTagView = false
+    @State private var showNlpInfoPopover = false
+    @State private var isReady = false
+
+    @FocusState private var focusedField: FormField?
+    enum FormField {
+        case nlp
+        case description
+        case project
+    }
+
+    private var hasUnsavedContent: Bool {
+        !nlpInput.isEmpty || !description.isEmpty
+    }
+
+    private func calculateNextField() {
+        switch focusedField {
+        case .nlp: focusedField = .description
+        case .description: focusedField = .project
+        case .project: focusedField = .project
+        default: focusedField = nil
+        }
+    }
+
+    private func calculatePreviousField() {
+        switch focusedField {
+        case .nlp: focusedField = .nlp
+        case .description: focusedField = .nlp
+        case .project: focusedField = .description
+        default: focusedField = nil
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextEditor(text: $nlpInput)
+                        .font(.system(.body, design: .monospaced))
+                        .autocapitalization(.none)
+                        .autocorrectionDisabled()
+                        .focused($focusedField, equals: .nlp)
+                        .onChange(of: nlpInput) { _, input in
+                            let nlpTask = NLPService.shared.createTask(from: input)
+                            self.description = nlpTask.description
+                            self.project = nlpTask.project ?? ""
+                            self.priority = nlpTask.priority ?? .none
+                            self.tags = nlpTask.tags ?? []
+                            if let due = nlpTask.due {
+                                didSetDate = true
+                                didSetTime = true
+                                let calendar = Calendar.current
+                                let dateComponents = calendar.dateComponents(
+                                    [.year, .month, .day], from: due
+                                )
+                                let timeComponents = calendar.dateComponents(
+                                    [.hour, .minute, .second], from: due
+                                )
+                                self.due = calendar.date(from: dateComponents) ?? .init()
+                                time = calendar.date(from: timeComponents) ?? .init()
+                                isTimeShowing = false
+                            } else {
+                                didSetDate = false
+                                didSetTime = false
+                                isDateShowing = false
+                                isTimeShowing = false
+                                due = .init()
+                                time = .init()
+                            }
+                        }
+                } header: {
+                    HStack {
+                        Text("Command Line Input")
+                        Button {
+                            showNlpInfoPopover.toggle()
+                        } label: {
+                            Image(systemName: SFSymbols.questionmarkCircle.rawValue)
+                        }
+                        .popover(
+                            isPresented: $showNlpInfoPopover,
+                            attachmentAnchor: .point(.bottom)
+                        ) {
+                            ScrollView {
+                                VStack(alignment: .leading, spacing: 10) {
+                                    Text(
+                                        "Create a task via a command line input. The format is as follows:"
+                                    )
+                                    .padding(.top)
+                                    Text(
+                                        "New Task due:tomorrow at 1pm project:my-project prio:M +my-tag"
+                                    )
+                                    .font(.system(.body, design: .monospaced))
+                                    Text(
+                                        "Manually updating the fields will override the values from the command line input."
+                                    )
+                                    .bold()
+                                    .padding(.bottom)
+                                }
+                            }
+                            .textCase(nil)
+                            .frame(minHeight: 150)
+                            .padding()
+                            .presentationCompactAdaptation(.popover)
+                        }
+                    }
+                }
+                Section {
+                    TextEditor(text: $description)
+                        .focused($focusedField, equals: .description)
+                        .bold()
+                    TextField("Project", text: $project)
+                        .focused($focusedField, equals: .project)
+                } header: {
+                    Text("Description")
+                }
+                Section {
+                    ShareDateToggleButton(
+                        isOnlyTime: false,
+                        date: $due,
+                        isSet: $didSetDate,
+                        isDateShowing: $isDateShowing
+                    )
+                    ShareDateToggleButton(
+                        isOnlyTime: true,
+                        date: $time,
+                        isSet: $didSetTime,
+                        isDateShowing: $isTimeShowing
+                    )
+                }
+                Section {
+                    Picker(
+                        "Priority",
+                        systemImage: SFSymbols.exclamationmark.rawValue,
+                        selection: $priority
+                    ) {
+                        Text(TCTask.Priority.none.rawValue.capitalized)
+                            .tag(TCTask.Priority.none)
+                        Divider()
+                        ForEach(TCTask.Priority.allCases, id: \.self) { priority in
+                            if priority != .none {
+                                Text(priority.rawValue.capitalized)
+                            }
+                        }
+                    }
+                    ShareAddTagButton(tags: $tags) {
+                        showTagView = true
+                    }
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") {
+                        createTask()
+                    }
+                    .bold()
+                }
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") {
+                        if hasUnsavedContent {
+                            showDismissConfirmation = true
+                        } else {
+                            onCancel()
+                        }
+                    }
+                }
+                ToolbarItem(placement: .keyboard) {
+                    HStack {
+                        if focusedField != .nlp {
+                            Button(action: calculatePreviousField) {
+                                Label("Previous", systemImage: SFSymbols.chevronUp.rawValue)
+                            }
+                            Button(action: calculateNextField) {
+                                Label("Next", systemImage: SFSymbols.chevronDown.rawValue)
+                            }
+                        }
+                        Spacer()
+                        if focusedField == .nlp {
+                            ShareAutocompleteBar(text: $nlpInput)
+                        }
+                        Spacer()
+                        Button(action: { focusedField = nil }) {
+                            Label(
+                                "Dismiss keyboard",
+                                systemImage: SFSymbols.checkmark.rawValue
+                            )
+                        }
+                    }
+                }
+            }
+            .onChange(of: didSetTime) { _, newValue in
+                if didSetTime {
+                    didSetDate = true
+                    isDateShowing = false
+                    withAnimation {
+                        isTimeShowing = newValue
+                    }
+                }
+            }
+            .onChange(of: didSetDate) { _, _ in
+                if !didSetDate {
+                    didSetTime = false
+                    isTimeShowing = false
+                } else if didSetDate, !didSetTime {
+                    withAnimation {
+                        isDateShowing = didSetDate
+                    }
+                }
+            }
+            .animation(.default, value: didSetDate)
+            .animation(.default, value: didSetTime)
+            .alert(isPresented: $isShowingAlert) {
+                Alert(
+                    title: Text(alertTitle),
+                    message: Text(alertMessage),
+                    dismissButton: .default(Text("OK"))
+                )
+            }
+            .confirmationDialog(
+                "Are you sure? This will dismiss without creating the task",
+                isPresented: $showDismissConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Dismiss task", role: .destructive) { onCancel() }
+                Button("Cancel", role: .cancel) {}
+            }
+            .navigationDestination(isPresented: $showTagView) {
+                ShareAddTagView(selectedTags: $tags)
+            }
+            .navigationTitle("New Task")
+            .navigationBarTitleDisplayMode(.inline)
+            .task {
+                await initializeServices()
+                if let sharedText {
+                    nlpInput = sharedText + " "
+                }
+                focusedField = .nlp
+            }
+        }
+    }
+
+    private func initializeServices() async {
+        do {
+            let destinationPath = try FileService.shared.getDestinationPathForLocalReplica()
+            try TaskchampionService.shared.setDbUrl(path: destinationPath)
+            isReady = true
+        } catch {
+            alertTitle = "Setup Error"
+            alertMessage = "Could not initialize task database."
+            isShowingAlert = true
+        }
+    }
+
+    private func createTask() {
+        guard isReady else {
+            alertTitle = "Not Ready"
+            alertMessage = "Task database is still initializing. Please try again."
+            isShowingAlert = true
+            return
+        }
+
+        if description.isEmpty {
+            alertTitle = "Missing field"
+            alertMessage = "Please enter a task name"
+            isShowingAlert = true
+            return
+        }
+
+        let finalDate = mergeDateWithTime(
+            date: didSetDate ? due : nil,
+            time: didSetTime ? time : nil
+        )
+
+        let task = TCTask(
+            uuid: UUID().uuidString,
+            project: project.isEmpty ? nil : project,
+            description: description,
+            status: .pending,
+            priority: priority == .none ? nil : priority,
+            due: finalDate,
+            tags: tags.isEmpty ? nil : tags
+        )
+
+        do {
+            try TaskchampionService.shared.createTask(task)
+            NotificationService.shared.requestAuthorization()
+            NotificationService.shared.createReminderForTask(task: task)
+            onComplete()
+        } catch {
+            alertTitle = "There was an error"
+            alertMessage = "Task failed to create. Please try again."
+            isShowingAlert = true
+        }
+    }
+
+    private func mergeDateWithTime(date: Date?, time: Date?) -> Date? {
+        guard let date else { return nil }
+        var components = Calendar.current.dateComponents([.year, .month, .day], from: date)
+        if let time {
+            let timeComponents = Calendar.current.dateComponents([.hour, .minute], from: time)
+            components.hour = timeComponents.hour
+            components.minute = timeComponents.minute
+        }
+        return Calendar.current.date(from: components)
+    }
+}
+
+// MARK: - Date Toggle Button
+
+private struct ShareDateToggleButton: View {
+    var isOnlyTime: Bool
+    @Binding var date: Date
+    @Binding var isSet: Bool
+    @Binding var isDateShowing: Bool
+
+    var body: some View {
+        Button(
+            action: {
+                if isSet {
+                    withAnimation {
+                        isDateShowing.toggle()
+                    }
+                }
+            },
+            label: {
+                Toggle(isOn: $isSet) {
+                    Label {
+                        HStack {
+                            Text(isOnlyTime ? "Time" : "Date")
+                                .foregroundStyle(.primary)
+                            if isSet {
+                                Text(" \u{2022} ")
+                                    .foregroundStyle(.tertiary)
+                                Text(date, style: isOnlyTime ? .time : .date)
+                                    .foregroundStyle(.tint)
+                                    .font(.footnote)
+                            }
+                        }
+                    } icon: {
+                        Image(
+                            systemName: isOnlyTime
+                                ? SFSymbols.clockFill.rawValue
+                                : SFSymbols.calendar.rawValue
+                        )
+                        .foregroundStyle(.tint)
+                    }
+                }
+            }
+        )
+        .foregroundStyle(.primary)
+        if isSet && isDateShowing {
+            HStack {
+                Spacer()
+                if isOnlyTime {
+                    DatePicker(
+                        "Time",
+                        selection: $date,
+                        displayedComponents: [.hourAndMinute]
+                    )
+                    .datePickerStyle(.wheel)
+                    .labelsHidden()
+                } else {
+                    DatePicker(
+                        "Date",
+                        selection: $date,
+                        displayedComponents: [.date]
+                    )
+                    .datePickerStyle(.graphical)
+                    .labelsHidden()
+                }
+                Spacer()
+            }
+            .listRowInsets(.init(top: 0, leading: 10, bottom: 0, trailing: 10))
+        }
+    }
+}
+
+// MARK: - Add Tag Button
+
+private struct ShareAddTagButton: View {
+    @Binding var tags: [TCTag]
+    var action: () -> Void
+
+    private var uniqueTags: [TCTag] {
+        var seen = Set<String>()
+        return tags.filter { tag in
+            if seen.contains(tag.name) {
+                return false
+            } else {
+                seen.insert(tag.name)
+                return true
+            }
+        }
+    }
+
+    var body: some View {
+        Button {
+            action()
+        } label: {
+            if tags.isEmpty {
+                Label("Tags", systemImage: SFSymbols.tag.rawValue)
+                    .labelStyle(.titleAndIcon)
+            } else {
+                Label {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack {
+                            ForEach(uniqueTags, id: \.self) { tag in
+                                Text(tag.name)
+                                    .font(.system(.body, design: .monospaced))
+                                    .padding(5)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 5)
+                                            .fill(Color.accentColor.opacity(0.2))
+                                    )
+                            }
+                        }
+                    }
+                    .onTapGesture {
+                        action()
+                    }
+                } icon: {
+                    Image(systemName: SFSymbols.tag.rawValue)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Autocomplete Bar
+
+private struct ShareAutocompleteBar: View {
+    @Binding var text: String
+
+    private var suggestions: [String] {
+        NLPService.shared.autoCompleteSuggestions(for: text, surface: .creation)
+    }
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack {
+                ForEach(suggestions, id: \.self) { suggestion in
+                    Button {
+                        text = NLPService.shared.getAutoCompletedString(
+                            for: text, suggestion: suggestion
+                        )
+                    } label: {
+                        Text(suggestion)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(
+                                RoundedRectangle(cornerRadius: 5)
+                                    .fill(Color.accentColor.opacity(0.2))
+                            )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/taskchampShareExtension/Sources/ShareViewController.swift
+++ b/taskchampShareExtension/Sources/ShareViewController.swift
@@ -1,0 +1,108 @@
+import SwiftData
+import SwiftUI
+import taskchampShared
+import UIKit
+import UniformTypeIdentifiers
+
+class ShareViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let container = try? ModelContainer(for: TCFilter.self, TCTag.self)
+        SwiftDataService.shared.container = container
+
+        Task {
+            let sharedText = await extractSharedText()
+            await MainActor.run {
+                setupComposeView(sharedText: sharedText, container: container)
+            }
+        }
+    }
+
+    private func setupComposeView(sharedText: String?, container: ModelContainer?) {
+        let composeView = ShareComposeView(
+            sharedText: sharedText,
+            onComplete: { [weak self] in
+                self?.extensionContext?.completeRequest(returningItems: nil)
+            },
+            onCancel: { [weak self] in
+                self?.extensionContext?.cancelRequest(
+                    withError: NSError(domain: "com.mav.taskchamp.share", code: 0)
+                )
+            }
+        )
+
+        let hostingController: UIHostingController<AnyView>
+        if let container {
+            hostingController = UIHostingController(
+                rootView: AnyView(composeView.modelContainer(container))
+            )
+        } else {
+            hostingController = UIHostingController(rootView: AnyView(composeView))
+        }
+
+        addChild(hostingController)
+        view.addSubview(hostingController.view)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+        hostingController.didMove(toParent: self)
+    }
+
+    private func extractSharedText() async -> String? {
+        guard let extensionItems = extensionContext?.inputItems as? [NSExtensionItem] else {
+            return nil
+        }
+
+        for item in extensionItems {
+            guard let attachments = item.attachments else { continue }
+            for provider in attachments {
+                if provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) {
+                    if let text = await loadText(from: provider) {
+                        return text
+                    }
+                }
+                if provider.hasItemConformingToTypeIdentifier(UTType.url.identifier) {
+                    if let url = await loadURL(from: provider) {
+                        return url
+                    }
+                }
+            }
+        }
+        return nil
+    }
+
+    private func loadURL(from provider: NSItemProvider) async -> String? {
+        await withCheckedContinuation { continuation in
+            provider.loadItem(forTypeIdentifier: UTType.url.identifier) { item, _ in
+                if let url = item as? URL {
+                    continuation.resume(returning: url.absoluteString)
+                } else if let nsURL = item as? NSURL {
+                    continuation.resume(returning: nsURL.absoluteString)
+                } else if let data = item as? Data {
+                    continuation.resume(returning: String(data: data, encoding: .utf8))
+                } else {
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
+    }
+
+    private func loadText(from provider: NSItemProvider) async -> String? {
+        await withCheckedContinuation { continuation in
+            provider.loadItem(forTypeIdentifier: UTType.plainText.identifier) { item, _ in
+                if let text = item as? String {
+                    continuation.resume(returning: text)
+                } else if let data = item as? Data {
+                    continuation.resume(returning: String(data: data, encoding: .utf8))
+                } else {
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
+    }
+}

--- a/taskchampShared/Sources/Utilities/UserDefaults.swift
+++ b/taskchampShared/Sources/Utilities/UserDefaults.swift
@@ -28,6 +28,8 @@ public enum TCUserDefaults: String {
 
     case storeKitPremiumUnlocked
     case storeKitCloudSubscriptionActive
+
+    case pendingNewTaskContent
 }
 
 public class UserDefaultsManager {

--- a/taskchampWidget/Sources/QuickAddWidget.swift
+++ b/taskchampWidget/Sources/QuickAddWidget.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import taskchampShared
+import WidgetKit
+
+struct QuickAddCircularWidget: Widget {
+    let kind: String = "QuickAddCircularWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: QuickAddProvider()) { _ in
+            ZStack {
+                AccessoryWidgetBackground()
+                Image(systemName: SFSymbols.plus.rawValue)
+                    .font(.title)
+                    .fontWeight(.semibold)
+            }
+            .widgetURL(TCTask.newTaskUrl)
+            .containerBackground(.background, for: .widget)
+        }
+        .configurationDisplayName("Quick Add")
+        .description("Quickly create a new task")
+        .supportedFamilies([.accessoryCircular])
+    }
+}
+
+private struct QuickAddProvider: TimelineProvider {
+    func placeholder(in _: Context) -> QuickAddEntry {
+        QuickAddEntry(date: Date())
+    }
+
+    func getSnapshot(in _: Context, completion: @escaping (QuickAddEntry) -> Void) {
+        completion(QuickAddEntry(date: Date()))
+    }
+
+    func getTimeline(in _: Context, completion: @escaping (Timeline<QuickAddEntry>) -> Void) {
+        let entry = QuickAddEntry(date: Date())
+        completion(Timeline(entries: [entry], policy: .never))
+    }
+}
+
+private struct QuickAddEntry: TimelineEntry {
+    let date: Date
+}

--- a/taskchampWidget/Sources/TaskchampWidgetBundle.swift
+++ b/taskchampWidget/Sources/TaskchampWidgetBundle.swift
@@ -5,5 +5,6 @@ import WidgetKit
 struct TaskchampWidgetBundle: WidgetBundle {
     var body: some Widget {
         TaskchampWidget()
+        QuickAddCircularWidget()
     }
 }


### PR DESCRIPTION
This PR focuses on some quality of life enhancements in the form of quickly adding tasks. I yet have to figure out how to build the Alpha for myself for this.

# feat: Share sheet

This adds the ability to share URLs and selected text to Taskchamp and
create a task from it. It targets the cli input for now. My plan is to
add support for annotations in the future and have it save the shared
content that way

https://github.com/user-attachments/assets/ba8dda9a-792e-4156-8cb8-ff3cf2882708

_Adding a task via Share Sheet_

# feat: Quick add widget and shortcut

- Added widget for homescreen to open quick add
- Updated shortcut to open quick add with the option to pre fill

https://github.com/user-attachments/assets/74dc60b7-8d27-4454-a229-b07c24213562

_Adding a task via lockscreen_

https://github.com/user-attachments/assets/c4a24e1a-9304-41dc-83b0-01a7f3fdc512

_Adding a task via Shortcuts_

 # feat: UI tweaks

- Changed buttons to Cancel and Add when adding a task
- Unified look of buttons
- Made Description field on tasks with long description grow with
content
- Set long Descriptions in the list view to a two line maximum followed
by ...

<img width="1206" height="2622" alt="Ui tweaks buttons" src="https://github.com/user-attachments/assets/d336ed6d-1530-4775-9670-3e8733d75731" />

<img width="1206" height="2622" alt="Description grows with content" src="https://github.com/user-attachments/assets/87bb48e1-0e06-4df9-905c-03f47be73455" />

<img width="1206" height="2622" alt="Ui two lines max" src="https://github.com/user-attachments/assets/a4ed4527-2da8-46c5-bc9e-4a982e79cb0b" />