### PR TITLE
feat: Filtering rework

### DIFF
--- a/taskchamp/Sources/Intents/FilterAppEntity.swift
+++ b/taskchamp/Sources/Intents/FilterAppEntity.swift
@@ -32,7 +32,7 @@ struct FilterEntityQuery: EntityQuery {
         let savedFilters = getSavedFiltersFromUserDefaults()
         results
             .append(contentsOf: savedFilters.map {
-                FilterAppEntity(id: $0.id.uuidString, name: $0.fullDescription)
+                FilterAppEntity(id: $0.id.uuidString, name: $0.displayName)
             }
             .filter { identifiers.contains($0.id) })
         return results
@@ -41,7 +41,7 @@ struct FilterEntityQuery: EntityQuery {
     func suggestedEntities() async throws -> [FilterAppEntity] {
         var results: [FilterAppEntity] = [.noFilter]
         results.append(contentsOf: getSavedFiltersFromUserDefaults().map {
-            FilterAppEntity(id: $0.id.uuidString, name: $0.fullDescription)
+            FilterAppEntity(id: $0.id.uuidString, name: $0.displayName)
         })
         return results
     }

--- a/taskchamp/Sources/View/AddFilterView.swift
+++ b/taskchamp/Sources/View/AddFilterView.swift
@@ -15,7 +15,8 @@ public struct AddFilterView: View, UseKeyboardToolbar {
 
     @State private var showNlpInfoPopover = false
     @State private var nlpInput = ""
-    @State private var nlpPlaceholder = "project:my-project prio:M status:pending +tag-to-include -tag-to-exclude"
+    @State private var nlpPlaceholder =
+        "project:my-project prio:M status:pending +tag -tag\n(project:A or project:B) +urgent"
     @State private var showPaywall = false
 
     @State private var isShowingAlert = false

--- a/taskchamp/Sources/View/AddFilterView.swift
+++ b/taskchamp/Sources/View/AddFilterView.swift
@@ -11,7 +11,7 @@ public struct AddFilterView: View, UseKeyboardToolbar {
     @Environment(\.dismiss) var dismiss
     @Binding var selectedFilter: TCFilter
 
-    @Query var filters: [TCFilter]
+    @Query(sort: \TCFilter.order) var filters: [TCFilter]
 
     @State private var showNlpInfoPopover = false
     @State private var nlpInput = ""
@@ -22,6 +22,10 @@ public struct AddFilterView: View, UseKeyboardToolbar {
     @State private var isShowingAlert = false
     @State private var alertTitle = ""
     @State private var alertMessage = ""
+
+    @State private var editingFilter: TCFilter?
+    @State private var editName = ""
+    @State private var editQuery = ""
 
     @FocusState private var isFocusedNLP: Bool
 
@@ -54,6 +58,73 @@ public struct AddFilterView: View, UseKeyboardToolbar {
         } catch { print(error) }
     }
 
+    private func addFilter() {
+        if !storeKit.hasPremiumAccess() {
+            showPaywall = true
+            return
+        }
+        withAnimation {
+            if nlpInput.isEmpty {
+                alertTitle = "Empty input"
+                alertMessage = "Please enter a valid filter"
+                isShowingAlert = true
+                return
+            }
+            let nlpFilter = NLPService.shared.createFilter(from: nlpInput)
+            if !nlpFilter.isValidFilter {
+                alertTitle = "Invalid filter"
+                alertMessage = "Please enter a valid filter"
+                isShowingAlert = true
+                return
+            }
+            nlpFilter.order = filters.count
+            modelContext.insert(nlpFilter)
+            selectedFilter = nlpFilter
+
+            setSelectedFilterUserDefault(selectedFilter: selectedFilter)
+
+            nlpInput = ""
+            isFocusedNLP = false
+            dismiss()
+        }
+    }
+
+    private func moveFilters(from source: IndexSet, to destination: Int) {
+        var reordered = filters
+        reordered.move(fromOffsets: source, toOffset: destination)
+        for (index, filter) in reordered.enumerated() {
+            filter.order = index
+        }
+        syncFiltersToSharedUserDefaults()
+    }
+
+    private func saveEditingFilter() {
+        guard let filter = editingFilter else { return }
+        let trimmedQuery = editQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedQuery.isEmpty {
+            alertTitle = "Empty query"
+            alertMessage = "Please enter a valid filter query"
+            isShowingAlert = true
+            return
+        }
+        let testFilter = NLPService.shared.createFilter(from: trimmedQuery)
+        if !testFilter.isValidFilter {
+            alertTitle = "Invalid filter"
+            alertMessage = "Please enter a valid filter query"
+            isShowingAlert = true
+            return
+        }
+        let trimmedName = editName.trimmingCharacters(in: .whitespacesAndNewlines)
+        filter.name = trimmedName.isEmpty ? nil : trimmedName
+        filter.fullDescription = trimmedQuery
+        if selectedFilter.id == filter.id {
+            selectedFilter = filter
+            setSelectedFilterUserDefault(selectedFilter: selectedFilter)
+        }
+        syncFiltersToSharedUserDefaults()
+        editingFilter = nil
+    }
+
     public var body: some View {
         NavigationStack {
             Form {
@@ -68,33 +139,7 @@ public struct AddFilterView: View, UseKeyboardToolbar {
                         }
                         .submitLabel(.go)
                         .onSubmit {
-                            if !storeKit.hasPremiumAccess() {
-                                showPaywall = true
-                                return
-                            }
-                            withAnimation {
-                                if nlpInput.isEmpty {
-                                    alertTitle = "Empty input"
-                                    alertMessage = "Please enter a valid filter"
-                                    isShowingAlert = true
-                                    return
-                                }
-                                let nlpFilter = NLPService.shared.createFilter(from: nlpInput)
-                                if !nlpFilter.isValidFilter {
-                                    alertTitle = "Invalid filter"
-                                    alertMessage = "Please enter a valid filter"
-                                    isShowingAlert = true
-                                    return
-                                }
-                                modelContext.insert(nlpFilter)
-                                selectedFilter = nlpFilter
-
-                                setSelectedFilterUserDefault(selectedFilter: selectedFilter)
-
-                                nlpInput = ""
-                                isFocusedNLP = false
-                                dismiss()
-                            }
+                            addFilter()
                         }
                 } header: {
                     HStack {
@@ -145,15 +190,43 @@ public struct AddFilterView: View, UseKeyboardToolbar {
                                 setSelectedFilterUserDefault(selectedFilter: selectedFilter)
                                 dismiss()
                             } label: {
-                                HStack {
-                                    Text(
-                                        filter.fullDescription
-                                    )
-                                    .font(.system(.body, design: .monospaced))
-                                    if selectedFilter.id == filter.id {
-                                        Spacer()
-                                        Image(systemName: SFSymbols.checkmark.rawValue)
+                                VStack(alignment: .leading, spacing: 4) {
+                                    if let name = filter.name, !name.isEmpty {
+                                        Text(name)
+                                            .font(.body)
                                     }
+                                    HStack {
+                                        Text(filter.fullDescription)
+                                            .font(.system(.body, design: .monospaced))
+                                            .foregroundStyle(
+                                                filter.name != nil && !filter.name!.isEmpty
+                                                    ? .secondary : .primary
+                                            )
+                                        if selectedFilter.id == filter.id {
+                                            Spacer()
+                                            Image(systemName: SFSymbols.checkmark.rawValue)
+                                        }
+                                    }
+                                }
+                            }
+                            .contextMenu {
+                                Button {
+                                    editName = filter.name ?? ""
+                                    editQuery = filter.fullDescription
+                                    editingFilter = filter
+                                } label: {
+                                    Label("Edit", systemImage: "pencil")
+                                }
+                                Button(role: .destructive) {
+                                    withAnimation {
+                                        modelContext.delete(filter)
+                                        if filter == selectedFilter {
+                                            selectedFilter = TCFilter.defaultFilter
+                                            setSelectedFilterUserDefault(selectedFilter: selectedFilter)
+                                        }
+                                    }
+                                } label: {
+                                    Label("Delete", systemImage: SFSymbols.trash.rawValue)
                                 }
                             }
                             .swipeActions(edge: .leading, allowsFullSwipe: true) {
@@ -170,6 +243,7 @@ public struct AddFilterView: View, UseKeyboardToolbar {
                                 }
                             }
                         }
+                        .onMove(perform: moveFilters)
                     }
                 }
             }
@@ -177,6 +251,11 @@ public struct AddFilterView: View, UseKeyboardToolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button("Back") {
                         dismiss()
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    if !filters.isEmpty {
+                        EditButton()
                     }
                 }
                 ToolbarItem(placement: .keyboard) {
@@ -204,6 +283,37 @@ public struct AddFilterView: View, UseKeyboardToolbar {
             }
             .alert(isPresented: $isShowingAlert) {
                 Alert(title: Text(alertTitle), message: Text(alertMessage), dismissButton: .default(Text("OK")))
+            }
+            .sheet(item: $editingFilter) { filter in
+                NavigationStack {
+                    Form {
+                        Section(header: Text("Name")) {
+                            TextField("Filter name (optional)", text: $editName)
+                        }
+                        Section(header: Text("Query")) {
+                            TextField("Filter query", text: $editQuery)
+                                .font(.system(.body, design: .monospaced))
+                                .autocapitalization(.none)
+                                .autocorrectionDisabled()
+                        }
+                    }
+                    .navigationTitle("Edit Filter")
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Cancel") {
+                                editingFilter = nil
+                            }
+                        }
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Save") {
+                                saveEditingFilter()
+                            }
+                            .bold()
+                        }
+                    }
+                }
+                .presentationDetents([.medium])
             }
             .navigationDestination(isPresented: $showPaywall) {
                 TCPaywall()

--- a/taskchamp/Sources/View/AddFilterView.swift
+++ b/taskchamp/Sources/View/AddFilterView.swift
@@ -107,8 +107,7 @@ public struct AddFilterView: View, UseKeyboardToolbar {
             isShowingAlert = true
             return
         }
-        let testFilter = NLPService.shared.createFilter(from: trimmedQuery)
-        if !testFilter.isValidFilter {
+        if FilterParser.parse(trimmedQuery) == nil {
             alertTitle = "Invalid filter"
             alertMessage = "Please enter a valid filter query"
             isShowingAlert = true

--- a/taskchamp/Sources/View/Cells/TaskCellView.swift
+++ b/taskchamp/Sources/View/Cells/TaskCellView.swift
@@ -26,6 +26,11 @@ public struct TaskCellView: View {
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }
+                if task.isActive {
+                    Image(systemName: SFSymbols.play.rawValue)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
                 if task.isRecurring, let recur = task.recur {
                     HStack(spacing: 4) {
                         Image(systemName: SFSymbols.recurringTask.rawValue)

--- a/taskchamp/Sources/View/EditTaskView-Ext.swift
+++ b/taskchamp/Sources/View/EditTaskView-Ext.swift
@@ -66,6 +66,26 @@ extension EditTaskView {
         }
     }
 
+    func handleStartStopTap() {
+        do {
+            globalState.isSyncingTasks = true
+            if task.isActive {
+                try TaskchampionService.shared.stopTask(task.uuid) {
+                    globalState.isSyncingTasks = false
+                }
+            } else {
+                try TaskchampionService.shared.startTask(task.uuid) {
+                    globalState.isSyncingTasks = false
+                }
+            }
+            task = try TaskchampionService.shared.getTask(uuid: task.uuid)
+        } catch {
+            isShowingAlert = true
+            alertTitle = "There was an error"
+            alertMessage = "Failed to \(task.isActive ? "stop" : "start") task. Please try again."
+        }
+    }
+
     func handleTaskActionTap() {
         do {
             globalState.isSyncingTasks = true

--- a/taskchamp/Sources/View/EditTaskView-Ext.swift
+++ b/taskchamp/Sources/View/EditTaskView-Ext.swift
@@ -73,10 +73,11 @@ extension EditTaskView {
                 try TaskchampionService.shared.stopTask(task.uuid) {
                     globalState.isSyncingTasks = false
                 }
-            } else {
-                try TaskchampionService.shared.startTask(task.uuid) {
-                    globalState.isSyncingTasks = false
-                }
+                task = try TaskchampionService.shared.getTask(uuid: task.uuid)
+                return
+            }
+            try TaskchampionService.shared.startTask(task.uuid) {
+                globalState.isSyncingTasks = false
             }
             task = try TaskchampionService.shared.getTask(uuid: task.uuid)
         } catch {

--- a/taskchamp/Sources/View/EditTaskView.swift
+++ b/taskchamp/Sources/View/EditTaskView.swift
@@ -148,6 +148,23 @@ public struct EditTaskView: View, UseKeyboardToolbar {
                     showTagPopover = true
                 }
             }
+            if task.status == .pending {
+                Section {
+                    Button(action: {
+                        handleStartStopTap()
+                    }, label: {
+                        Label(
+                            task.isActive ? "Stop task" : "Start task",
+                            systemImage: task.isActive ? SFSymbols.stopFill.rawValue : SFSymbols.playFill.rawValue
+                        )
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                        .foregroundStyle(.white)
+                    })
+                    .buttonStyle(.borderedProminent)
+                    .tint(task.isActive ? .orange : .green)
+                    .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+                }
+            }
             Section {
                 Button(action: {
                     handleTaskActionTap()

--- a/taskchamp/Sources/View/TaskListView-Ext.swift
+++ b/taskchamp/Sources/View/TaskListView-Ext.swift
@@ -20,6 +20,26 @@ extension TaskListView {
         return editMode.isEditing == true
     }
 
+    func toggleStartStop(_ task: TCTask) {
+        withAnimation {
+            do {
+                globalState.isSyncingTasks = true
+                if task.isActive {
+                    try TaskchampionService.shared.stopTask(task.uuid) {
+                        globalState.isSyncingTasks = false
+                    }
+                } else {
+                    try TaskchampionService.shared.startTask(task.uuid) {
+                        globalState.isSyncingTasks = false
+                    }
+                }
+                updateTasks()
+            } catch {
+                print(error)
+            }
+        }
+    }
+
     func updateTasks(_ uuids: Set<String>, withStatus newStatus: TCTask.Status) {
         withAnimation {
             do {

--- a/taskchamp/Sources/View/TaskListView.swift
+++ b/taskchamp/Sources/View/TaskListView.swift
@@ -317,7 +317,7 @@ public struct TaskListView: View {
                 isEditModeActive ?
                 selection
                 .isEmpty ? "Select Tasks" : "\(selection.count) Selected" :
-                selectedFilter.fullDescription
+                selectedFilter.displayName
         )
         .environment(\.editMode, $editMode)
         .onChange(of: scenePhase) { _, newScenePhase in

--- a/taskchamp/Sources/View/TaskListView.swift
+++ b/taskchamp/Sources/View/TaskListView.swift
@@ -91,6 +91,18 @@ public struct TaskListView: View {
                             )
                         }
                         .tint(task.isCompleted ? .yellow : .green)
+                        if task.status == .pending {
+                            Button {
+                                toggleStartStop(task)
+                            } label: {
+                                Label(
+                                    task.isActive ? "Stop" : "Start",
+                                    systemImage: task.isActive ? SFSymbols.stopFill.rawValue : SFSymbols.playFill
+                                        .rawValue
+                                )
+                            }
+                            .tint(task.isActive ? .orange : .blue)
+                        }
                     }
                 }
                 .swipeActions(edge: .leading, allowsFullSwipe: true) {

--- a/taskchampShared/Sources/Models/FilterExpression.swift
+++ b/taskchampShared/Sources/Models/FilterExpression.swift
@@ -1,0 +1,221 @@
+import Foundation
+
+// MARK: - FilterExpression
+
+public indirect enum FilterExpression {
+    case and([FilterExpression])
+    case or([FilterExpression])
+    case tag(String)
+    case notTag(String)
+    case project(String)
+    case priority(TCTask.Priority)
+    case status(TCTask.Status)
+    case recur
+
+    public func matches(_ task: TCTask) -> Bool {
+        switch self {
+        case .and(let expressions):
+            return expressions.allSatisfy { $0.matches(task) }
+        case .or(let expressions):
+            return expressions.contains { $0.matches(task) }
+        case .tag(let name):
+            return task.tags?.contains { $0.name == name } ?? false
+        case .notTag(let name):
+            return !(task.tags?.contains { $0.name == name } ?? false)
+        case .project(let name):
+            return task.project == name
+        case .priority(let prio):
+            let taskPrio = task.priority ?? .none
+            return taskPrio == prio
+        case .status(let status):
+            return task.status == status
+        case .recur:
+            return task.recur != nil
+        }
+    }
+
+    func containsStatus(_ status: TCTask.Status) -> Bool {
+        switch self {
+        case .status(let taskStatus):
+            return taskStatus == status
+        case .and(let expressions), .or(let expressions):
+            return expressions.contains { $0.containsStatus(status) }
+        default:
+            return false
+        }
+    }
+}
+
+// MARK: - FilterToken
+
+enum FilterToken: Equatable {
+    case leftParen
+    case rightParen
+    case orKeyword
+    case andKeyword
+    case tag(String)
+    case notTag(String)
+    case project(String)
+    case priority(String)
+    case status(String)
+    case recur
+}
+
+// MARK: - FilterParser
+
+public struct FilterParser {
+
+    // MARK: - Public API
+
+    public static func parse(_ input: String) -> FilterExpression? {
+        let tokens = tokenize(input)
+        guard !tokens.isEmpty else { return nil }
+        var index = 0
+        let result = parseOrExpression(tokens: tokens, index: &index)
+        return result
+    }
+
+    // MARK: - Tokenizer
+
+    static func tokenize(_ input: String) -> [FilterToken] {
+        var tokens: [FilterToken] = []
+        let chars = Array(input)
+        var i = 0
+
+        while i < chars.count {
+            if chars[i].isWhitespace {
+                i += 1
+                continue
+            }
+
+            if chars[i] == "(" {
+                tokens.append(.leftParen)
+                i += 1
+                continue
+            }
+
+            if chars[i] == ")" {
+                tokens.append(.rightParen)
+                i += 1
+                continue
+            }
+
+            var word = ""
+            while i < chars.count && !chars[i].isWhitespace && chars[i] != "(" && chars[i] != ")" {
+                word.append(chars[i])
+                i += 1
+            }
+
+            guard !word.isEmpty else { continue }
+
+            if word.lowercased() == "or" {
+                tokens.append(.orKeyword)
+            } else if word.lowercased() == "and" {
+                tokens.append(.andKeyword)
+            } else if word.hasPrefix("project:") {
+                tokens.append(.project(String(word.dropFirst("project:".count))))
+            } else if word.hasPrefix("prio:") {
+                tokens.append(.priority(String(word.dropFirst("prio:".count))))
+            } else if word.hasPrefix("status:") {
+                tokens.append(.status(String(word.dropFirst("status:".count))))
+            } else if word.lowercased() == "recur" {
+                tokens.append(.recur)
+            } else if word.hasPrefix("+") {
+                let value = String(word.dropFirst())
+                if !value.isEmpty {
+                    tokens.append(.tag(value))
+                }
+            } else if word.hasPrefix("-") {
+                let value = String(word.dropFirst())
+                if !value.isEmpty {
+                    tokens.append(.notTag(value))
+                }
+            }
+        }
+
+        return tokens
+    }
+
+    // MARK: - Recursive Descent Parser
+    //
+    // Grammar:
+    //   expression = or_expr
+    //   or_expr    = and_expr ("or" and_expr)*
+    //   and_expr   = primary ("and"? primary)*
+    //   primary    = "(" expression ")" | atom
+    //   atom       = tag | notTag | project | priority | status | recur
+
+    private static func parseOrExpression(tokens: [FilterToken], index: inout Int) -> FilterExpression? {
+        guard let first = parseAndExpression(tokens: tokens, index: &index) else { return nil }
+
+        var operands = [first]
+        while index < tokens.count && tokens[index] == .orKeyword {
+            index += 1
+            guard let next = parseAndExpression(tokens: tokens, index: &index) else { break }
+            operands.append(next)
+        }
+
+        return operands.count == 1 ? operands[0] : .or(operands)
+    }
+
+    private static func parseAndExpression(tokens: [FilterToken], index: inout Int) -> FilterExpression? {
+        guard let first = parsePrimary(tokens: tokens, index: &index) else { return nil }
+
+        var operands = [first]
+        while index < tokens.count && tokens[index] != .orKeyword && tokens[index] != .rightParen {
+            if tokens[index] == .andKeyword {
+                index += 1
+            }
+            guard let next = parsePrimary(tokens: tokens, index: &index) else { break }
+            operands.append(next)
+        }
+
+        return operands.count == 1 ? operands[0] : .and(operands)
+    }
+
+    private static func parsePrimary(tokens: [FilterToken], index: inout Int) -> FilterExpression? {
+        guard index < tokens.count else { return nil }
+
+        if tokens[index] == .leftParen {
+            index += 1
+            guard let expr = parseOrExpression(tokens: tokens, index: &index) else { return nil }
+            if index < tokens.count && tokens[index] == .rightParen {
+                index += 1
+            }
+            return expr
+        }
+
+        return parseAtom(tokens: tokens, index: &index)
+    }
+
+    private static func parseAtom(tokens: [FilterToken], index: inout Int) -> FilterExpression? {
+        guard index < tokens.count else { return nil }
+
+        let token = tokens[index]
+
+        switch token {
+        case .tag(let name):
+            index += 1
+            return .tag(name)
+        case .notTag(let name):
+            index += 1
+            return .notTag(name)
+        case .project(let value):
+            index += 1
+            return .project(value)
+        case .priority(let value):
+            index += 1
+            guard let prio = TCTask.Priority(rawValue: value) else { return nil }
+            return .priority(prio)
+        case .status(let value):
+            index += 1
+            guard let status = TCTask.Status(rawValue: value) else { return nil }
+            return .status(status)
+        case .recur:
+            index += 1
+            return .recur
+        default:
+            return nil
+        }
+    }
+}

--- a/taskchampShared/Sources/Models/FilterExpression.swift
+++ b/taskchampShared/Sources/Models/FilterExpression.swift
@@ -108,28 +108,31 @@ public struct FilterParser {
 
             guard !word.isEmpty else { continue }
 
-            if word.lowercased() == "or" {
+            switch word {
+            case _ where word.lowercased() == "or":
                 tokens.append(.orKeyword)
-            } else if word.lowercased() == "and" {
+            case _ where word.lowercased() == "and":
                 tokens.append(.andKeyword)
-            } else if word.hasPrefix("project:") {
+            case _ where word.hasPrefix("project:"):
                 tokens.append(.project(String(word.dropFirst("project:".count))))
-            } else if word.hasPrefix("prio:") {
+            case _ where word.hasPrefix("prio:"):
                 tokens.append(.priority(String(word.dropFirst("prio:".count))))
-            } else if word.hasPrefix("status:") {
+            case _ where word.hasPrefix("status:"):
                 tokens.append(.status(String(word.dropFirst("status:".count))))
-            } else if word.lowercased() == "recur" {
+            case _ where word.lowercased() == "recur":
                 tokens.append(.recur)
-            } else if word.hasPrefix("+") {
+            case _ where word.hasPrefix("+"):
                 let value = String(word.dropFirst())
                 if !value.isEmpty {
                     tokens.append(.tag(value))
                 }
-            } else if word.hasPrefix("-") {
+            case _ where word.hasPrefix("-"):
                 let value = String(word.dropFirst())
                 if !value.isEmpty {
                     tokens.append(.notTag(value))
                 }
+            default:
+                break
             }
         }
 

--- a/taskchampShared/Sources/Models/TCFilter.swift
+++ b/taskchampShared/Sources/Models/TCFilter.swift
@@ -24,6 +24,8 @@ public class TCFilter: Codable {
     }
 
     public var id = UUID()
+    public var name: String?
+    public var order: Int = 0
     public var fullDescription: String = ""
     public var project: String = ""
     public var status = TCTask.Status.deleted
@@ -40,6 +42,13 @@ public class TCFilter: Codable {
     public var didSetStatus: Bool = false
     public var didSetTags: Bool = false
     public var didSetRecur: Bool = false
+
+    public var displayName: String {
+        if let name, !name.isEmpty {
+            return name
+        }
+        return fullDescription
+    }
 
     public var realDue: Date? {
         return didSetDue ? due : nil
@@ -113,12 +122,16 @@ public class TCFilter: Codable {
     }
 
     init(
+        name: String? = nil,
+        order: Int = 0,
         fullDescription: String = "",
         project: String = "",
         status: TCTask.Status = .deleted,
         priority: TCTask.Priority = .none,
         due: Date = Date(timeIntervalSince1970: 0)
     ) {
+        self.name = name
+        self.order = order
         self.fullDescription = fullDescription
         self.project = project
         self.status = status
@@ -128,6 +141,8 @@ public class TCFilter: Codable {
 
     enum CodingKeys: CodingKey {
         case id
+        case name
+        case order
         case fullDescription
         case project
         case status
@@ -146,6 +161,8 @@ public class TCFilter: Codable {
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decodeIfPresent(String.self, forKey: .name)
+        order = try container.decodeIfPresent(Int.self, forKey: .order) ?? 0
         fullDescription = try container.decode(String.self, forKey: .fullDescription)
         project = try container.decode(String.self, forKey: .project)
         status = try container.decode(TCTask.Status.self, forKey: .status)
@@ -167,6 +184,8 @@ public class TCFilter: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encode(order, forKey: .order)
         try container.encode(fullDescription, forKey: .fullDescription)
         try container.encode(project, forKey: .project)
         try container.encode(status, forKey: .status)

--- a/taskchampShared/Sources/Models/TCFilter.swift
+++ b/taskchampShared/Sources/Models/TCFilter.swift
@@ -45,7 +45,12 @@ public class TCFilter: Codable {
         return didSetDue ? due : nil
     }
 
+    public var filterExpression: FilterExpression? {
+        return FilterParser.parse(fullDescription)
+    }
+
     public var isValidFilter: Bool {
+        if filterExpression != nil { return true }
         return didSetPrio || didSetProject || didSetDue || didSetStatus || didSetTags || didSetRecur
     }
 

--- a/taskchampShared/Sources/Models/TCSyntheticTag.swift
+++ b/taskchampShared/Sources/Models/TCSyntheticTag.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+public enum TCSyntheticTag: String, CaseIterable {
+    case overdue = "OVERDUE"
+    case due = "DUE"
+    case dueToday = "DUETODAY"
+    case today = "TODAY"
+    case yesterday = "YESTERDAY"
+    case tomorrow = "TOMORROW"
+    case week = "WEEK"
+    case month = "MONTH"
+    case quarter = "QUARTER"
+    case year = "YEAR"
+    case annotated = "ANNOTATED"
+    case tagged = "TAGGED"
+    case priority = "PRIORITY"
+    case project = "PROJECT"
+    case parent = "PARENT"
+    case child = "CHILD"
+    case ready = "READY"
+    case scheduled = "SCHEDULED"
+    case until = "UNTIL"
+    case latest = "LATEST"
+
+    public func toTCTag() -> TCTag {
+        TCTag(name: rawValue)
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    public func applies(
+        to task: TCTask,
+        hasAnnotations: Bool = false,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> Bool {
+        switch self {
+        case .overdue:
+            guard let due = task.due else { return false }
+            return due < now
+        case .due:
+            guard let due = task.due,
+                  let sevenDaysFromNow = calendar.date(byAdding: .day, value: 7, to: now) else {
+                return false
+            }
+            return due <= sevenDaysFromNow
+        case .dueToday, .today:
+            guard let due = task.due else { return false }
+            return calendar.isDateInToday(due)
+        case .yesterday:
+            guard let due = task.due else { return false }
+            return calendar.isDateInYesterday(due)
+        case .tomorrow:
+            guard let due = task.due else { return false }
+            return calendar.isDateInTomorrow(due)
+        case .week:
+            guard let due = task.due else { return false }
+            return calendar.isDate(due, equalTo: now, toGranularity: .weekOfYear)
+        case .month:
+            guard let due = task.due else { return false }
+            return calendar.isDate(due, equalTo: now, toGranularity: .month)
+        case .quarter:
+            guard let due = task.due else { return false }
+            let dueQuarter = (calendar.component(.month, from: due) - 1) / 3
+            let nowQuarter = (calendar.component(.month, from: now) - 1) / 3
+            return calendar.component(.year, from: due) == calendar.component(.year, from: now)
+                && dueQuarter == nowQuarter
+        case .year:
+            guard let due = task.due else { return false }
+            return calendar.isDate(due, equalTo: now, toGranularity: .year)
+        case .annotated:
+            return hasAnnotations
+        case .tagged:
+            return task.tags?.contains(where: { !$0.isSynthetic() }) ?? false
+        case .priority:
+            guard let priority = task.priority else { return false }
+            return priority != .none
+        case .project:
+            guard let project = task.project else { return false }
+            return !project.isEmpty
+        case .parent:
+            return task.status == .recurring
+        case .child:
+            return task.recur != nil && task.status != .recurring
+        case .ready:
+            guard task.status == .pending else { return false }
+            let existingTagNames = Set((task.tags ?? []).map { $0.name })
+            return !existingTagNames.contains("BLOCKED") && !existingTagNames.contains("WAITING")
+        case .scheduled:
+            return task.scheduled != nil
+        case .until:
+            return task.until != nil
+        case .latest:
+            // LATEST is collection-dependent; see TCTask.markLatestTask(in:).
+            return false
+        }
+    }
+}

--- a/taskchampShared/Sources/Models/TCTag.swift
+++ b/taskchampShared/Sources/Models/TCTag.swift
@@ -63,6 +63,9 @@ public class TCTag: Codable, Equatable {
     }
 
     public func isSynthetic() -> Bool {
+        if !name.isEmpty && name.allSatisfy({ $0.isASCII && $0.isLetter && $0.isUppercase }) {
+            return true
+        }
         return rustTag?.is_synthetic() ?? false
     }
 

--- a/taskchampShared/Sources/Models/TCTask.swift
+++ b/taskchampShared/Sources/Models/TCTask.swift
@@ -260,6 +260,10 @@ public struct TCTask: Codable, Hashable {
         return rustVec
     }
 
+    public var isActive: Bool {
+        tags?.contains(where: { $0.name == "ACTIVE" }) ?? false
+    }
+
     public var isCompleted: Bool {
         status == .completed
     }

--- a/taskchampShared/Sources/Models/TCTask.swift
+++ b/taskchampShared/Sources/Models/TCTask.swift
@@ -84,6 +84,9 @@ public struct TCTask: Codable, Hashable {
         let annotations = rustTask.get_annotations().map { $0.get_description().toString() }
         let tags = rustTask.get_tags().map { TCTag.tagFactory(name: $0.get_value().toString()) }
         let recur = rustTask.get_recur()?.toString()
+        let scheduled = rustTask.get_scheduled()?.toString()
+        let until = rustTask.get_until()?.toString()
+        let modified = rustTask.get_modified()?.toString()
 
         // Initialize
         self.uuid = uuid
@@ -97,6 +100,15 @@ public struct TCTask: Codable, Hashable {
         }
         self.project = project
         self.recur = recur
+        if let scheduled, let timeInterval = TimeInterval(scheduled) {
+            self.scheduled = Date(timeIntervalSince1970: timeInterval)
+        }
+        if let until, let timeInterval = TimeInterval(until) {
+            self.until = Date(timeIntervalSince1970: timeInterval)
+        }
+        if let modified, let timeInterval = TimeInterval(modified) {
+            self.modified = Date(timeIntervalSince1970: timeInterval)
+        }
 
         // Look for obsidian note in annotations
         var obsidianNoteValue: String?
@@ -212,6 +224,9 @@ public struct TCTask: Codable, Hashable {
     public var noteAnnotationKey: String?
     public var tags: [TCTag]?
     public var recur: String?
+    public var scheduled: Date?
+    public var until: Date?
+    public var modified: Date?
 
     public var obsidianNoteAnnotation: String? {
         guard let note = obsidianNote else {
@@ -430,11 +445,36 @@ public struct TCTask: Codable, Hashable {
             syntheticTags.append(TCTag(name: "READY"))
         }
 
+        // SCHEDULED
+        if scheduled != nil && !existingTagNames.contains("SCHEDULED") {
+            syntheticTags.append(TCTag(name: "SCHEDULED"))
+        }
+
+        // UNTIL
+        if until != nil && !existingTagNames.contains("UNTIL") {
+            syntheticTags.append(TCTag(name: "UNTIL"))
+        }
+
         if !syntheticTags.isEmpty {
             if self.tags == nil {
                 self.tags = syntheticTags
             } else {
                 self.tags?.append(contentsOf: syntheticTags)
+            }
+        }
+    }
+
+    public static func markLatestTask(in tasks: inout [TCTask]) {
+        guard let latestIndex = tasks.enumerated().max(by: { lhs, rhs in
+            (lhs.element.modified ?? .distantPast) < (rhs.element.modified ?? .distantPast)
+        })?.offset else { return }
+
+        let existingTagNames = Set((tasks[latestIndex].tags ?? []).map { $0.name })
+        if !existingTagNames.contains("LATEST") {
+            if tasks[latestIndex].tags == nil {
+                tasks[latestIndex].tags = [TCTag(name: "LATEST")]
+            } else {
+                tasks[latestIndex].tags?.append(TCTag(name: "LATEST"))
             }
         }
     }

--- a/taskchampShared/Sources/Models/TCTask.swift
+++ b/taskchampShared/Sources/Models/TCTask.swift
@@ -141,6 +141,7 @@ public struct TCTask: Codable, Hashable {
         obsidianNote = obsidianNoteValue
 
         self.tags = tags.isEmpty ? nil : tags
+        appendSwiftSyntheticTags(hasAnnotations: !annotations.isEmpty)
     }
 
     public init(from decoder: Decoder) throws {
@@ -349,5 +350,122 @@ public struct TCTask: Codable, Hashable {
         }
 
         return url
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
+    private mutating func appendSwiftSyntheticTags(hasAnnotations: Bool) {
+        var syntheticTags: [TCTag] = []
+        let existingTagNames = Set((tags ?? []).map { $0.name })
+        let now = Date()
+        let calendar = Calendar.current
+
+        if let due = due {
+            // OVERDUE
+            if due < now && !existingTagNames.contains("OVERDUE") {
+                syntheticTags.append(TCTag(name: "OVERDUE"))
+            }
+
+            // DUE: due within 7 days (includes overdue)
+            if let sevenDaysFromNow = calendar.date(byAdding: .day, value: 7, to: now),
+               due <= sevenDaysFromNow && !existingTagNames.contains("DUE") {
+                syntheticTags.append(TCTag(name: "DUE"))
+            }
+
+            // DUETODAY / TODAY
+            if calendar.isDateInToday(due) {
+                if !existingTagNames.contains("DUETODAY") {
+                    syntheticTags.append(TCTag(name: "DUETODAY"))
+                }
+                if !existingTagNames.contains("TODAY") {
+                    syntheticTags.append(TCTag(name: "TODAY"))
+                }
+            }
+
+            // YESTERDAY
+            if calendar.isDateInYesterday(due) && !existingTagNames.contains("YESTERDAY") {
+                syntheticTags.append(TCTag(name: "YESTERDAY"))
+            }
+
+            // TOMORROW
+            if calendar.isDateInTomorrow(due) && !existingTagNames.contains("TOMORROW") {
+                syntheticTags.append(TCTag(name: "TOMORROW"))
+            }
+
+            // WEEK
+            if calendar.isDate(due, equalTo: now, toGranularity: .weekOfYear)
+                && !existingTagNames.contains("WEEK") {
+                syntheticTags.append(TCTag(name: "WEEK"))
+            }
+
+            // MONTH
+            if calendar.isDate(due, equalTo: now, toGranularity: .month)
+                && !existingTagNames.contains("MONTH") {
+                syntheticTags.append(TCTag(name: "MONTH"))
+            }
+
+            // QUARTER
+            let dueQuarter = (calendar.component(.month, from: due) - 1) / 3
+            let nowQuarter = (calendar.component(.month, from: now) - 1) / 3
+            if calendar.component(.year, from: due) == calendar.component(.year, from: now)
+                && dueQuarter == nowQuarter
+                && !existingTagNames.contains("QUARTER") {
+                syntheticTags.append(TCTag(name: "QUARTER"))
+            }
+
+            // YEAR
+            if calendar.isDate(due, equalTo: now, toGranularity: .year)
+                && !existingTagNames.contains("YEAR") {
+                syntheticTags.append(TCTag(name: "YEAR"))
+            }
+        }
+
+        // ANNOTATED
+        if hasAnnotations && !existingTagNames.contains("ANNOTATED") {
+            syntheticTags.append(TCTag(name: "ANNOTATED"))
+        }
+
+        // TAGGED: has any user (non-synthetic) tags
+        if let tags = tags, tags.contains(where: { !$0.isSynthetic() })
+            && !existingTagNames.contains("TAGGED") {
+            syntheticTags.append(TCTag(name: "TAGGED"))
+        }
+
+        // PRIORITY
+        if let priority = priority, priority != .none
+            && !existingTagNames.contains("PRIORITY") {
+            syntheticTags.append(TCTag(name: "PRIORITY"))
+        }
+
+        // PROJECT
+        if let project = project, !project.isEmpty
+            && !existingTagNames.contains("PROJECT") {
+            syntheticTags.append(TCTag(name: "PROJECT"))
+        }
+
+        // PARENT: recurring template
+        if status == .recurring && !existingTagNames.contains("PARENT") {
+            syntheticTags.append(TCTag(name: "PARENT"))
+        }
+
+        // CHILD: recurring instance
+        if recur != nil && status != .recurring && !existingTagNames.contains("CHILD") {
+            syntheticTags.append(TCTag(name: "CHILD"))
+        }
+
+        // READY: pending, not blocked, not waiting
+        if status == .pending
+            && !existingTagNames.contains("BLOCKED")
+            && !existingTagNames.contains("WAITING")
+            && !existingTagNames.contains("READY") {
+            syntheticTags.append(TCTag(name: "READY"))
+        }
+
+        if !syntheticTags.isEmpty {
+            if self.tags == nil {
+                self.tags = syntheticTags
+            } else {
+                self.tags?.append(contentsOf: syntheticTags)
+            }
+        }
     }
 }

--- a/taskchampShared/Sources/Models/TCTask.swift
+++ b/taskchampShared/Sources/Models/TCTask.swift
@@ -337,130 +337,21 @@ public struct TCTask: Codable, Hashable {
         return url
     }
 
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
     private mutating func appendSwiftSyntheticTags(hasAnnotations: Bool) {
-        var syntheticTags: [TCTag] = []
         let existingTagNames = Set((tags ?? []).map { $0.name })
-        let now = Date()
-        let calendar = Calendar.current
-
-        if let due = due {
-            // OVERDUE
-            if due < now && !existingTagNames.contains("OVERDUE") {
-                syntheticTags.append(TCTag(name: "OVERDUE"))
+        let syntheticTags = TCSyntheticTag.allCases
+            .filter { tag in
+                tag != .latest
+                    && !existingTagNames.contains(tag.rawValue)
+                    && tag.applies(to: self, hasAnnotations: hasAnnotations)
             }
+            .map { $0.toTCTag() }
 
-            // DUE: due within 7 days (includes overdue)
-            if let sevenDaysFromNow = calendar.date(byAdding: .day, value: 7, to: now),
-               due <= sevenDaysFromNow && !existingTagNames.contains("DUE") {
-                syntheticTags.append(TCTag(name: "DUE"))
-            }
-
-            // DUETODAY / TODAY
-            if calendar.isDateInToday(due) {
-                if !existingTagNames.contains("DUETODAY") {
-                    syntheticTags.append(TCTag(name: "DUETODAY"))
-                }
-                if !existingTagNames.contains("TODAY") {
-                    syntheticTags.append(TCTag(name: "TODAY"))
-                }
-            }
-
-            // YESTERDAY
-            if calendar.isDateInYesterday(due) && !existingTagNames.contains("YESTERDAY") {
-                syntheticTags.append(TCTag(name: "YESTERDAY"))
-            }
-
-            // TOMORROW
-            if calendar.isDateInTomorrow(due) && !existingTagNames.contains("TOMORROW") {
-                syntheticTags.append(TCTag(name: "TOMORROW"))
-            }
-
-            // WEEK
-            if calendar.isDate(due, equalTo: now, toGranularity: .weekOfYear)
-                && !existingTagNames.contains("WEEK") {
-                syntheticTags.append(TCTag(name: "WEEK"))
-            }
-
-            // MONTH
-            if calendar.isDate(due, equalTo: now, toGranularity: .month)
-                && !existingTagNames.contains("MONTH") {
-                syntheticTags.append(TCTag(name: "MONTH"))
-            }
-
-            // QUARTER
-            let dueQuarter = (calendar.component(.month, from: due) - 1) / 3
-            let nowQuarter = (calendar.component(.month, from: now) - 1) / 3
-            if calendar.component(.year, from: due) == calendar.component(.year, from: now)
-                && dueQuarter == nowQuarter
-                && !existingTagNames.contains("QUARTER") {
-                syntheticTags.append(TCTag(name: "QUARTER"))
-            }
-
-            // YEAR
-            if calendar.isDate(due, equalTo: now, toGranularity: .year)
-                && !existingTagNames.contains("YEAR") {
-                syntheticTags.append(TCTag(name: "YEAR"))
-            }
-        }
-
-        // ANNOTATED
-        if hasAnnotations && !existingTagNames.contains("ANNOTATED") {
-            syntheticTags.append(TCTag(name: "ANNOTATED"))
-        }
-
-        // TAGGED: has any user (non-synthetic) tags
-        if let tags = tags, tags.contains(where: { !$0.isSynthetic() })
-            && !existingTagNames.contains("TAGGED") {
-            syntheticTags.append(TCTag(name: "TAGGED"))
-        }
-
-        // PRIORITY
-        if let priority = priority, priority != .none
-            && !existingTagNames.contains("PRIORITY") {
-            syntheticTags.append(TCTag(name: "PRIORITY"))
-        }
-
-        // PROJECT
-        if let project = project, !project.isEmpty
-            && !existingTagNames.contains("PROJECT") {
-            syntheticTags.append(TCTag(name: "PROJECT"))
-        }
-
-        // PARENT: recurring template
-        if status == .recurring && !existingTagNames.contains("PARENT") {
-            syntheticTags.append(TCTag(name: "PARENT"))
-        }
-
-        // CHILD: recurring instance
-        if recur != nil && status != .recurring && !existingTagNames.contains("CHILD") {
-            syntheticTags.append(TCTag(name: "CHILD"))
-        }
-
-        // READY: pending, not blocked, not waiting
-        if status == .pending
-            && !existingTagNames.contains("BLOCKED")
-            && !existingTagNames.contains("WAITING")
-            && !existingTagNames.contains("READY") {
-            syntheticTags.append(TCTag(name: "READY"))
-        }
-
-        // SCHEDULED
-        if scheduled != nil && !existingTagNames.contains("SCHEDULED") {
-            syntheticTags.append(TCTag(name: "SCHEDULED"))
-        }
-
-        // UNTIL
-        if until != nil && !existingTagNames.contains("UNTIL") {
-            syntheticTags.append(TCTag(name: "UNTIL"))
-        }
-
-        if !syntheticTags.isEmpty {
-            if self.tags == nil {
-                self.tags = syntheticTags
-            } else {
-                self.tags?.append(contentsOf: syntheticTags)
-            }
+        guard !syntheticTags.isEmpty else { return }
+        if self.tags == nil {
+            self.tags = syntheticTags
+        } else {
+            self.tags?.append(contentsOf: syntheticTags)
         }
     }
 
@@ -469,13 +360,14 @@ public struct TCTask: Codable, Hashable {
             (lhs.element.modified ?? .distantPast) < (rhs.element.modified ?? .distantPast)
         })?.offset else { return }
 
+        let latestTag = TCSyntheticTag.latest
         let existingTagNames = Set((tasks[latestIndex].tags ?? []).map { $0.name })
-        if !existingTagNames.contains("LATEST") {
-            if tasks[latestIndex].tags == nil {
-                tasks[latestIndex].tags = [TCTag(name: "LATEST")]
-            } else {
-                tasks[latestIndex].tags?.append(TCTag(name: "LATEST"))
-            }
+        guard !existingTagNames.contains(latestTag.rawValue) else { return }
+
+        if tasks[latestIndex].tags == nil {
+            tasks[latestIndex].tags = [latestTag.toTCTag()]
+        } else {
+            tasks[latestIndex].tags?.append(latestTag.toTCTag())
         }
     }
 }

--- a/taskchampShared/Sources/Models/TCTask.swift
+++ b/taskchampShared/Sources/Models/TCTask.swift
@@ -54,57 +54,23 @@ public struct TCTask: Codable, Hashable {
     }
 
     @MainActor
-    // swiftlint:disable:next cyclomatic_complexity
     public static func taskFactory(from rustTask: TaskRef, withFilter filter: TCFilter) -> TCTask? {
         // Exclude recurring template tasks unless explicitly filtering for them
         let statusValue = rustTask.get_status().get_value().toString().lowercased()
         if statusValue == "recurring" {
-            if !filter.didSetStatus || filter.status != .recurring {
+            guard let expression = filter.filterExpression,
+                  expression.containsStatus(.recurring) else {
                 return nil
             }
         }
 
-        let prio = rustTask.get_priority().toString()
-        if filter.didSetPrio {
-            if prio != filter.priority.rawValue {
-                return nil
-            }
+        let task = TCTask(from: rustTask)
+
+        guard let expression = filter.filterExpression else {
+            return task
         }
 
-        let project = rustTask.get_project()?.toString() ?? ""
-        if filter.didSetProject {
-            if project != filter.project {
-                return nil
-            }
-        }
-
-        if filter.didSetStatus {
-            if statusValue != filter.status.rawValue {
-                return nil
-            }
-        }
-
-        if filter.didSetTags {
-            let tagsToInclude = filter.tagsToInclude
-            let tagsToExclude = filter.tagsToExclude
-            let rustTags = rustTask.get_tags().map { $0.get_value().toString }
-            for tag in tagsToInclude ?? [] where !rustTags.contains(where: { $0() == tag.name }) {
-                return nil
-            }
-            for tag in tagsToExclude ?? [] where rustTags.contains(where: { $0() == tag.name }) {
-                return nil
-            }
-        }
-
-        // Filter for recurring task instances (tasks with recur property set)
-        if filter.didSetRecur {
-            let recur = rustTask.get_recur()?.toString()
-            if recur == nil {
-                return nil
-            }
-        }
-
-        return TCTask(from: rustTask)
+        return expression.matches(task) ? task : nil
     }
 
     @MainActor

--- a/taskchampShared/Sources/Services/NLPService.swift
+++ b/taskchampShared/Sources/Services/NLPService.swift
@@ -31,6 +31,7 @@ public class NLPService {
             "project:",
             "status:",
             "recur",
+            "or",
             "+",
             "-"
         ],
@@ -82,7 +83,7 @@ public class NLPService {
 
     private func autoCompleteSourcesNotAlreadyInInput(_ input: String, surface: Surface) -> [String] {
         return (autoCompleteSources[surface] ?? []).filter {
-            if isTag($0) {
+            if isTag($0) || $0 == "or" {
                 return true
             }
             return !input.contains($0)
@@ -226,53 +227,36 @@ public class NLPService {
         let filter = TCFilter(
             fullDescription: input
         )
-        var remainingString = input
 
-        // Check for and extract prio
-        if remainingString.range(of: "prio:") != nil {
-            let prio = extractValue(after: "prio:", from: &remainingString, isFilter: true)
-            filter.setPrio(TCTask.Priority(rawValue: prio ?? ""))
+        guard let expression = FilterParser.parse(input) else {
+            return filter
         }
 
-        // Check for and extract project
-        if remainingString.range(of: "project:") != nil {
-            filter.setProject(extractValue(after: "project:", from: &remainingString, isFilter: true))
-        }
-
-        // Check for and extract due
-        if remainingString.range(of: "due:") != nil {
-            filter.setDue(extractValue(after: "due:", from: &remainingString, isFilter: true)?.dateValue)
-        }
-
-        // Check for and extract status
-        if remainingString.range(of: "status:") != nil {
-            let status = extractValue(after: "status:", from: &remainingString, isFilter: true)
-            filter.setStatus(TCTask.Status(rawValue: status ?? "pending"))
-        }
-
-        // Check for recur keyword (filters for recurring task instances)
-        if let range = remainingString.range(of: "\\brecur\\b", options: .regularExpression) {
-            filter.setRecur()
-            remainingString.removeSubrange(range)
-        }
-
-        // Check for and extract tags
-        while remainingString.range(of: "+") != nil {
-            let tagValue = extractValue(after: "+", from: &remainingString)
-            if let tagValue, !tagValue.isEmpty {
-                filter.setTag(tagValue, forInclusion: true)
-            }
-        }
-
-        // Check for and extract negative tags
-        while remainingString.range(of: "-") != nil {
-            let tagValue = extractValue(after: "-", from: &remainingString)
-            if let tagValue, !tagValue.isEmpty {
-                filter.setTag(tagValue, forInclusion: false)
-            }
-        }
+        setLegacyProperties(on: filter, from: expression)
 
         return filter
+    }
+
+    @MainActor
+    private func setLegacyProperties(on filter: TCFilter, from expression: FilterExpression) {
+        switch expression {
+        case .and(let expressions), .or(let expressions):
+            for expr in expressions {
+                setLegacyProperties(on: filter, from: expr)
+            }
+        case .project(let name):
+            filter.setProject(name)
+        case .priority(let prio):
+            filter.setPrio(prio)
+        case .status(let status):
+            filter.setStatus(status)
+        case .tag(let name):
+            filter.setTag(name, forInclusion: true)
+        case .notTag(let name):
+            filter.setTag(name, forInclusion: false)
+        case .recur:
+            filter.setRecur()
+        }
     }
 
     // TODO: Add recur: to regex patterns when recurring task creation is implemented

--- a/taskchampShared/Sources/Services/TaskchampionService.swift
+++ b/taskchampShared/Sources/Services/TaskchampionService.swift
@@ -128,6 +128,7 @@ public class TaskchampionService {
         var taskObjects: [TCTask] = []
         if filter.isDefaultFilter {
             taskObjects = try getPendingTasks()
+            TCTask.markLatestTask(in: &taskObjects)
             TasksHelper.sortTasksWithSortType(&taskObjects, sortType: sortType)
             return taskObjects
         }
@@ -144,6 +145,7 @@ public class TaskchampionService {
             return nil
         }
 
+        TCTask.markLatestTask(in: &taskObjects)
         TasksHelper.sortTasksWithSortType(&taskObjects, sortType: sortType)
         return taskObjects
     }

--- a/taskchampShared/Sources/Services/TaskchampionService.swift
+++ b/taskchampShared/Sources/Services/TaskchampionService.swift
@@ -257,6 +257,38 @@ public class TaskchampionService {
         }
     }
 
+    public func startTask(_ uuid: String, onSync: @escaping () -> Void = {}) throws {
+        guard let replica else {
+            throw TCError.genericError("Database not set")
+        }
+        let task = replica.start_task(uuid.intoRustString())
+        if task == nil {
+            throw TCError.genericError("Failed to start task")
+        }
+        _ = replica.sync_no_server()
+        _Concurrency.Task.detached {
+            try? await self.sync {
+                onSync()
+            }
+        }
+    }
+
+    public func stopTask(_ uuid: String, onSync: @escaping () -> Void = {}) throws {
+        guard let replica else {
+            throw TCError.genericError("Database not set")
+        }
+        let task = replica.stop_task(uuid.intoRustString())
+        if task == nil {
+            throw TCError.genericError("Failed to stop task")
+        }
+        _ = replica.sync_no_server()
+        _Concurrency.Task.detached {
+            try? await self.sync {
+                onSync()
+            }
+        }
+    }
+
     public func createTask(_ task: TCTask, onSync: @escaping () -> Void = {}) throws {
         guard let replica else {
             throw TCError.genericError("Database not set")

--- a/taskchampShared/Sources/Utilities/SFSymbols.swift
+++ b/taskchampShared/Sources/Utilities/SFSymbols.swift
@@ -29,4 +29,7 @@ public enum SFSymbols: String {
     case cloudCheck = "checkmark.icloud"
     case tag
     case recurringTask = "repeat"
+    case play
+    case playFill = "play.fill"
+    case stopFill = "stop.fill"
 }

--- a/taskchampWidget/Sources/Intents/FilterAppEntity.swift
+++ b/taskchampWidget/Sources/Intents/FilterAppEntity.swift
@@ -32,7 +32,7 @@ struct FilterEntityQuery: EntityQuery {
         let savedFilters = getSavedFiltersFromUserDefaults()
         results
             .append(contentsOf: savedFilters.map {
-                FilterAppEntity(id: $0.id.uuidString, name: $0.fullDescription)
+                FilterAppEntity(id: $0.id.uuidString, name: $0.displayName)
             }
             .filter { identifiers.contains($0.id) })
         return results
@@ -41,7 +41,7 @@ struct FilterEntityQuery: EntityQuery {
     func suggestedEntities() async throws -> [FilterAppEntity] {
         var results: [FilterAppEntity] = [.noFilter]
         results.append(contentsOf: getSavedFiltersFromUserDefaults().map {
-            FilterAppEntity(id: $0.id.uuidString, name: $0.fullDescription)
+            FilterAppEntity(id: $0.id.uuidString, name: $0.displayName)
         })
         return results
     }


### PR DESCRIPTION
This is a big one addressing #114, #30, #97 and #113, that's why I'm opening this as a PR so we can have a critical look at it. This adds (in order of commits)

- Support for almost all VIRTUAL tags
- Support for `and`, `or` and `(EXPR)` based filters
- Start and Stop options for tasks
- Support to name filters, edit them and re-arrange them

Lets dive in

# Support for almost all VIRTUAL tags

Brings support for:

| Tag | Condition |
|-----|-----------|
| OVERDUE | due < now |
| DUE | due <= now + 7 days |
| DUETODAY / TODAY | due is today |
| YESTERDAY | due was yesterday |
| TOMORROW | due is tomorrow |
| WEEK | due is this calendar week |
| MONTH | due is this calendar month |
| QUARTER | due is this calendar quarter |
| YEAR | due is this calendar year |
| ANNOTATED | task has annotations |
| TAGGED | task has user (non-synthetic) tags |
| PRIORITY | task has a priority set |
| PROJECT | task has a project set |
| PARENT | status == .recurring |
| CHILD | recur != nil && status != .recurring |
| READY | pending + not BLOCKED + not WAITING (we don't have BLOCKED right now so thats an issue, see bellow) |
| ACTIVE | task has been started (Rust synthetic, from start key) |
| SCHEDULED | task has a scheduled date set |
| UNTIL | task has an until date set |
| LATEST | task with the most recent modified timestamp |

ACTIVE comes from the Rust layer (Taskchampion computes it from the start property). 

Missing tags are:

| Tag | Why not |
|-----|---------|
| ORPHAN | Requires cross-task lookup, check if parent UUID still exists in replica, can be added but might add overhead |
| UDA | Requires knowing which keys are standard vs user-defined, I don't think we need that right now |
| BLOCKED | Requires dependency tracking check if any dependency tasks are still pending, I would like to have this in the future |

This is the underlying logic that sets all the tags: https://github.com/marriagav/taskchamp/blob/460947f7e235dd5dd002a9c9c7d84d12bcf15947/taskchampShared/Sources/Models/TCTask.swift#L355-L461 
For now `DUE` = "Task is DUE in the next 7 days". This is the taskwarrior default and we could enable an option to set a custom _n_ in the future. Before that I would suggest a re-design of the settings in app

# Support for `and`, `or` and `(EXPR)` based filters

Support for filters like `+DUE or +ACTIVE` work, also `(+PENDING and +DUE) or +ACTIVE`.

https://github.com/user-attachments/assets/67223e6c-f8a2-4992-8955-81d478fb5d15

_Shows adding custom filter, editing the filter name, how named filter looks in the interface when selected and how it looks when selecting a named filter from a widget_

I have tested this on all my personal custom filters with production (my) data but it might need some more work. Tested filters are:

```shell
(+ACTIVE or +DUE or +OVERDUE) +READY
(+READY +PROJECT) -DUE -DUETODAY -OVERDUE -ACTIVE
(-COMPLETED -DELETED wait:someday)*
-COMPLETED -DELETED -TEMPLATE
(+COMPLETED)
-COMPLETED -DELETED -PROJECT
```

\* `wait:someday` does not work right now

# Start and Stop options for tasks

We can now Start and Stop tasks. I added a "play" icon to the UI to indicate an active task. Tasks can be stopped from the detail screen or by swiping left on them

https://github.com/user-attachments/assets/f9900c88-e775-4f74-820a-cc2db4134934

_Shows starting a task from list view and from the details view_

# Support to name filters, edit them and re-arrange them

After creating a filter we can edit it, give it a friendly name and we can re-arrange filters

# Bugs and future Enhancements 

- Start/Stop a task takes some time because it looks like it updates the tasks, syncs and waits for the sync to complete to update the status. I think we can make this nicer" if we handle it local first, sync later
- I don't like the UI whens Start/Stop a task from the details screen. The button is big and ugly. I think a small UI rework is in order, I have some ideas but I wanted this functionality first. 
- The start stop in the list view also looks so so
- Same for editing and managing filters, it could use some polish, the whole flow of adding, editing filters is verry raw right now.
- Filtering out task that `wait:DATE` does not work yet