### PR TITLE
fix: linting errors

### DIFF
--- a/taskchampShared/Sources/Models/FilterExpression.swift
+++ b/taskchampShared/Sources/Models/FilterExpression.swift
@@ -4,6 +4,7 @@ import Foundation
 
 public indirect enum FilterExpression {
     case and([FilterExpression])
+    // swiftlint:disable:next identifier_name
     case or([FilterExpression])
     case tag(String)
     case notTag(String)
@@ -63,8 +64,7 @@ enum FilterToken: Equatable {
 
 // MARK: - FilterParser
 
-public struct FilterParser {
-
+public enum FilterParser {
     // MARK: - Public API
 
     public static func parse(_ input: String) -> FilterExpression? {

--- a/taskchampShared/Sources/Models/TCSyntheticTag.swift
+++ b/taskchampShared/Sources/Models/TCSyntheticTag.swift
@@ -38,8 +38,10 @@ public enum TCSyntheticTag: String, CaseIterable {
             guard let due = task.due else { return false }
             return due < now
         case .due:
-            guard let due = task.due,
-                  let sevenDaysFromNow = calendar.date(byAdding: .day, value: 7, to: now) else {
+            guard
+                let due = task.due,
+                let sevenDaysFromNow = calendar.date(byAdding: .day, value: 7, to: now)
+            else {
                 return false
             }
             return due <= sevenDaysFromNow
@@ -70,7 +72,7 @@ public enum TCSyntheticTag: String, CaseIterable {
         case .annotated:
             return hasAnnotations
         case .tagged:
-            return task.tags?.contains(where: { !$0.isSynthetic() }) ?? false
+            return task.tags?.contains { !$0.isSynthetic() } ?? false
         case .priority:
             guard let priority = task.priority else { return false }
             return priority != .none

--- a/taskchampShared/Sources/Models/TCTask.swift
+++ b/taskchampShared/Sources/Models/TCTask.swift
@@ -58,8 +58,10 @@ public struct TCTask: Codable, Hashable {
         // Exclude recurring template tasks unless explicitly filtering for them
         let statusValue = rustTask.get_status().get_value().toString().lowercased()
         if statusValue == "recurring" {
-            guard let expression = filter.filterExpression,
-                  expression.containsStatus(.recurring) else {
+            guard
+                let expression = filter.filterExpression,
+                expression.containsStatus(.recurring)
+            else {
                 return nil
             }
         }
@@ -276,7 +278,7 @@ public struct TCTask: Codable, Hashable {
     }
 
     public var isActive: Bool {
-        tags?.contains(where: { $0.name == "ACTIVE" }) ?? false
+        tags?.contains { $0.name == "ACTIVE" } ?? false
     }
 
     public var isCompleted: Bool {


### PR DESCRIPTION
Fixed these errors:

taskchamp-public/taskchampShared/Sources/Models/TCTask.swift:62:1: warning: Indentation Width Violation: Code should be indented using one tab or 4 spaces (indentation_width)
taskchamp-public/taskchampShared/Sources/Models/TCTask.swift:279:31: warning: Trailing Closure Violation: Trailing closure syntax should be used whenever possible (trailing_closure)
taskchamp-public/taskchampShared/Sources/Models/FilterExpression.swift:66:8: warning: Convenience Type Violation: Types used for hosting only static members should be implemented as a caseless enum to avoid instantiation (convenience_type)
taskchamp-public/taskchampShared/Sources/Models/FilterExpression.swift:7:10: warning: Identifier Name Violation: Enum element name 'or' should be between 3 and 40 characters long (identifier_name)
taskchamp-public/taskchampShared/Sources/Models/FilterExpression.swift:67:1: warning: Vertical Whitespace after Opening Braces Violation: Don't include vertical whitespace (empty line) after opening braces (vertical_whitespace_opening_braces)
taskchamp-public/taskchampShared/Sources/Models/TCSyntheticTag.swift:42:1: warning: Indentation Width Violation: Code should be indented using one tab or 4 spaces (indentation_width)
taskchamp-public/taskchampShared/Sources/Models/TCSyntheticTag.swift:73:47: warning: Trailing Closure Violation: Trailing closure syntax should be used whenever possible (trailing_closure)